### PR TITLE
Relax pool metrics test double comparator

### DIFF
--- a/src/test/java/io/vertx/micrometer/VertxPoolMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxPoolMetricsTest.java
@@ -63,14 +63,16 @@ public class VertxPoolMetricsTest {
 
     List<RegistryInspector.Datapoint> timersDp = RegistryInspector.listTimers("vertx.pool.")
       .stream().filter(dp -> dp.id().startsWith("vertx.pool.")).collect(Collectors.toList());
-    assertThat(timersDp)
-      .usingFieldByFieldElementComparator()
-      .usingComparatorForElementFieldsWithType(new DoubleComparator(0.1), Double.class)
-      .hasSize(6)
+    assertThat(timersDp).hasSize(6)
       .contains(
         dp("vertx.pool.queue.delay[pool_name=test-worker,pool_type=worker]$COUNT", taskCount),
+        dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$COUNT", taskCount));
+
+    assertThat(timersDp)
+      .usingFieldByFieldElementComparator()
+      .usingComparatorForElementFieldsWithType(new DoubleComparator(1.0), Double.class)
+      .contains(
         dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$TOTAL_TIME", taskCount * sleepMillis / 1000d),
-        dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$COUNT", taskCount),
         dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$MAX", sleepMillis / 1000d));
   }
 }


### PR DESCRIPTION
From time to time CI tests fail due to timing uncertainty. So relaxing the rule.