### PR TITLE
Add ability to provide any MicrometerRegistry in options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-graphite</artifactId>
+      <version>${micrometer.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
       <optional>true</optional>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -39,7 +39,8 @@ Set the matched value.
 
 ++++
  Vert.x micrometer configuration.<br/>
- It is required to set either <code>influxDbOptions</code>, <code>prometheusOptions</code> or {@code jmxMetricsOptions]
+ It is required to set either <code>influxDbOptions</code>, <code>prometheusOptions</code> or <code>jmxMetricsOptions</code>
+ (or, programmatically, <code>micrometerRegistry</code>)
  in order to actually report metrics.
 ++++
 '''

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -8,7 +8,8 @@ It uses link:http://micrometer.io/[Micrometer] for managing metrics and reportin
 * Vert.x core tools monitoring: TCP/HTTP client and servers, {@link io.vertx.core.datagram.DatagramSocket}
 , {@link io.vertx.core.eventbus.EventBus} and pools
 * User defined metrics through Micrometer
-* Reporting to https://www.influxdata.com/[InfluxDB], https://prometheus.io/[Prometheus] or JMX.
+* Reporting to any backend supported by Micrometer
+* Built-in options for https://www.influxdata.com/[InfluxDB], https://prometheus.io/[Prometheus] and JMX reporting.
 
 == InfluxDB
 
@@ -180,6 +181,22 @@ MBeans are registered.
 [source,$lang]
 ----
 {@link examples.MetricsExamples#setupJMXWithStepAndDomain()}
+----
+
+== Other backends or combinations
+
+Even if not all backends supported by Micrometer are implemented in Vert.x options, it is still possible
+to create any Micrometer registry and pass it to Vert.x.
+
+The list of available backends includes Graphite, Ganglia, Atlas, link:http://micrometer.io/docs[etc].
+It also enables the link:http://micrometer.io/docs/concepts#_composite_registries[Micrometer Composite Registry]
+in order to report the same metrics to multiple backends.
+
+In this example, metrics are reported both for JMX and Graphite:
+
+[source,$lang]
+----
+{@link examples.MetricsExamples#setupWithCompositeRegistry()}
 ----
 
 == Advanced usage

--- a/src/main/java/examples/MetricsExamples.java
+++ b/src/main/java/examples/MetricsExamples.java
@@ -15,6 +15,7 @@
  */
 package examples;
 
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
@@ -22,7 +23,10 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.graphite.GraphiteMeterRegistry;
+import io.micrometer.jmx.JmxMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
@@ -225,5 +229,16 @@ public class MetricsExamples {
     // Client + server
     JsonObject metrics = metricsService.getMetricsSnapshot("vertx.http");
     System.out.println(metrics);
+  }
+
+  public void setupWithCompositeRegistry() {
+    CompositeMeterRegistry myRegistry = new CompositeMeterRegistry();
+    myRegistry.add(new JmxMeterRegistry(s -> null, Clock.SYSTEM));
+    myRegistry.add(new GraphiteMeterRegistry(s -> null, Clock.SYSTEM));
+
+    Vertx vertx = Vertx.vertx(new VertxOptions()
+      .setMetricsOptions(new MicrometerMetricsOptions()
+        .setMicrometerRegistry(myRegistry)
+        .setEnabled(true)));
   }
 }

--- a/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
+++ b/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.micrometer;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.json.JsonArray;
@@ -29,7 +30,8 @@ import java.util.Set;
 
 /**
  * Vert.x micrometer configuration.<br/>
- * It is required to set either {@code influxDbOptions}, {@code prometheusOptions} or {@code jmxMetricsOptions]
+ * It is required to set either {@code influxDbOptions}, {@code prometheusOptions} or {@code jmxMetricsOptions}
+ * (or, programmatically, {@code micrometerRegistry})
  * in order to actually report metrics.
  *
  * @author Joel Takvorian
@@ -70,6 +72,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
   private Set<MetricsDomain> disabledMetricsCategories;
   private String registryName;
   private List<Match> labelMatchs;
+  private MeterRegistry micrometerRegistry;
   private VertxInfluxDbOptions influxDbOptions;
   private VertxPrometheusOptions prometheusOptions;
   private VertxJmxMetricsOptions jmxMetricsOptions;
@@ -91,6 +94,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
     disabledMetricsCategories = other.disabledMetricsCategories != null ? EnumSet.copyOf(other.disabledMetricsCategories) : EnumSet.noneOf(MetricsDomain.class);
     registryName = other.registryName;
     labelMatchs = new ArrayList<>(other.labelMatchs);
+    micrometerRegistry = other.micrometerRegistry;
     if (other.influxDbOptions != null) {
       influxDbOptions = new VertxInfluxDbOptions(other.influxDbOptions);
     }
@@ -218,6 +222,38 @@ public class MicrometerMetricsOptions extends MetricsOptions {
    */
   public MicrometerMetricsOptions addLabelMatch(Match match) {
     labelMatchs.add(match);
+    return this;
+  }
+
+  /**
+   * Get the Micrometer MeterRegistry to be used by Vert.x, that has been previously set programmatically
+   *
+   * @return the micrometer registry.
+   */
+  public MeterRegistry getMicrometerRegistry() {
+    return micrometerRegistry;
+  }
+
+  /**
+   * Programmatically set the Micrometer MeterRegistry to be used by Vert.x.
+   *
+   * This is useful in several scenarios, such as:
+   * <ul>
+   *   <li>if there is already a MeterRegistry used in the application
+   * that should be used by Vert.x as well.</li>
+   *   <li>to define some backend configuration that is not covered in this module
+   * (example: reporting to non-covered backends such as New Relic)</li>
+   *   <li>to use Micrometer's CompositeRegistry</li>
+   * </ul>
+   *
+   * This setter is mutually exclusive with setInfluxDbOptions/setPrometheusOptions/setJmxMetricsOptions
+   * and takes precedence over them.
+   *
+   * @param micrometerRegistry the registry to use
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MicrometerMetricsOptions setMicrometerRegistry(MeterRegistry micrometerRegistry) {
+    this.micrometerRegistry = micrometerRegistry;
     return this;
   }
 

--- a/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
+++ b/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
@@ -20,11 +20,11 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.Vertx;
+import io.vertx.micrometer.Match;
 import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxInfluxDbOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
-import io.vertx.micrometer.Match;
 
 import java.util.List;
 import java.util.Map;
@@ -55,7 +55,9 @@ public final class BackendRegistries {
   public static BackendRegistry setupBackend(Vertx vertx, MicrometerMetricsOptions options) {
     return REGISTRIES.computeIfAbsent(options.getRegistryName(), k -> {
       final BackendRegistry reg;
-      if (options.getInfluxDbOptions() != null && options.getInfluxDbOptions().isEnabled()) {
+      if (options.getMicrometerRegistry() != null) {
+        reg = options::getMicrometerRegistry;
+      } else if (options.getInfluxDbOptions() != null && options.getInfluxDbOptions().isEnabled()) {
         reg = new InfluxDbBackendRegistry(options.getInfluxDbOptions());
       } else if (options.getPrometheusOptions() != null && options.getPrometheusOptions().isEnabled()) {
         reg = new PrometheusBackendRegistry(vertx, options.getPrometheusOptions());

--- a/src/main/java/io/vertx/micrometer/backends/BackendRegistry.java
+++ b/src/main/java/io/vertx/micrometer/backends/BackendRegistry.java
@@ -24,6 +24,6 @@ import io.vertx.core.eventbus.EventBus;
  */
 public interface BackendRegistry {
   MeterRegistry getMeterRegistry();
-  void eventBusInitialized(EventBus bus);
-  void close();
+  default void eventBusInitialized(EventBus bus) {}
+  default void close() {}
 }

--- a/src/test/java/io/vertx/micrometer/backend/CustomMicrometerMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/CustomMicrometerMetricsITest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.micrometer.backend;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.influx.InfluxConfig;
+import io.micrometer.influx.InfluxMeterRegistry;
+import io.micrometer.jmx.JmxMeterRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.micrometer.MetricsDomain;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(VertxUnitRunner.class)
+public class CustomMicrometerMetricsITest {
+
+  private static final String REGITRY_NAME = "CustomMicrometerMetricsITest";
+  private Vertx vertx;
+
+  @After
+  public void tearDown() {
+    BackendRegistries.stop(REGITRY_NAME);
+  }
+
+  @Test
+  public void shouldReportWithCompositeRegistry(TestContext context) throws Exception {
+    CompositeMeterRegistry myRegistry = new CompositeMeterRegistry();
+    myRegistry.add(new JmxMeterRegistry(s -> null, Clock.SYSTEM));
+    myRegistry.add(new InfluxMeterRegistry(new InfluxConfig() {
+      @Override
+      public String get(String s) {
+        return null;
+      }
+      @Override
+      public Duration step() {
+        return Duration.ofSeconds(1);
+      }
+      @Override
+      public String uri() {
+        return "http://localhost:8087";
+      }
+    }, Clock.SYSTEM));
+
+    vertx = Vertx.vertx(new VertxOptions()
+      .setMetricsOptions(new MicrometerMetricsOptions()
+        .setMicrometerRegistry(myRegistry)
+        .setRegistryName(REGITRY_NAME)
+        .addDisabledMetricsCategory(MetricsDomain.HTTP_SERVER)
+        .addDisabledMetricsCategory(MetricsDomain.NAMED_POOLS)
+        .setEnabled(true)));
+
+    // Mock an influxdb server
+    Async asyncInflux = context.async();
+    simulateInfluxServer(context, body -> {
+      try {
+        context.verify(w -> assertThat(body)
+          .contains("vertx_eventbus_handlers,address=test-eb,metric_type=gauge value=1"));
+      } finally {
+        asyncInflux.complete();
+      }
+    });
+
+    // Send something on the eventbus and wait til it's received
+    Async asyncEB = context.async();
+    vertx.eventBus().consumer("test-eb", msg -> asyncEB.complete());
+    vertx.eventBus().publish("test-eb", "test message");
+    asyncEB.await(2000);
+
+    // Read MBean
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    assertThat(mbs.getDomains()).contains("metrics");
+    Number result = (Number) mbs.getAttribute(new ObjectName("metrics", "name", "vertxEventbusHandlers.address.test-eb"), "Value");
+    assertThat(result).isEqualTo(1d);
+
+    // Await influx
+    asyncInflux.awaitSuccess();
+  }
+
+  private void simulateInfluxServer(TestContext context, Consumer<String> onRequest) {
+    vertx.runOnContext(v -> {
+      vertx.createHttpServer(new HttpServerOptions()
+        .setCompressionSupported(true)
+        .setDecompressionSupported(true)
+        .setLogActivity(true)
+        .setHost("localhost")
+        .setPort(8087))
+        .requestHandler(req -> {
+          req.exceptionHandler(context.exceptionHandler());
+          Buffer fullRequestBody = Buffer.buffer();
+          req.handler(fullRequestBody::appendBuffer);
+          req.endHandler(h -> {
+            String str = fullRequestBody.toString();
+            if (str.isEmpty()) {
+              req.response().setStatusCode(200).end();
+              return;
+            }
+            try {
+              onRequest.accept(str);
+            } finally {
+              req.response().setStatusCode(200).end();
+            }
+          });
+        }).listen(8087, "localhost", context.asyncAssertSuccess());
+    });
+  }
+}

--- a/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
@@ -42,7 +42,7 @@ public class InfluxDbReporterITest {
   public void setUp(TestContext context) {
     vertx = Vertx.vertx(new VertxOptions()
       .setMetricsOptions(new MicrometerMetricsOptions()
-        .setInfluxDbOptions(new VertxInfluxDbOptions().setEnabled(true)
+        .setInfluxDbOptions(new VertxInfluxDbOptions()
           .setStep(1)
           .setEnabled(true))
         .setRegistryName("influx")

--- a/src/test/java/io/vertx/micrometer/backend/InfluxDbTestHelper.java
+++ b/src/test/java/io/vertx/micrometer/backend/InfluxDbTestHelper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.micrometer.backend;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Joel Takvorian
+ */
+public final class InfluxDbTestHelper {
+  private InfluxDbTestHelper() {
+  }
+
+  static void simulateInfluxServer(Vertx vertx, TestContext context, int port, Consumer<String> onRequest) {
+    Async ready = context.async();
+    vertx.runOnContext(v -> vertx.createHttpServer(new HttpServerOptions()
+      .setCompressionSupported(true)
+      .setDecompressionSupported(true)
+      .setLogActivity(true)
+      .setHost("localhost")
+      .setPort(port))
+      .requestHandler(req -> {
+        req.exceptionHandler(context.exceptionHandler());
+        req.bodyHandler(buffer -> {
+          String str = buffer.toString();
+          if (str.isEmpty()) {
+            req.response().setStatusCode(200).end();
+            return;
+          }
+          try {
+            onRequest.accept(str);
+          } finally {
+            req.response().setStatusCode(200).end();
+          }
+        });
+      })
+      .exceptionHandler(System.err::println)
+      .listen(port, "localhost", res -> {
+        if (res.succeeded()) {
+          ready.complete();
+        } else {
+          context.fail(res.cause());
+        }
+      }));
+    ready.await(10000);
+  }
+}


### PR DESCRIPTION
MicrometerMetricsOptions now can take any existing MicrometerRegistry. In such case it won't go over the creation process of a backend-dedicated registry. It's also useful to allow Micrometer CompositeRegistry