### PR TITLE
Fix several test issues, potential race cond in Gauges.java, …

### DIFF
--- a/src/main/java/examples/MetricsExamples.java
+++ b/src/main/java/examples/MetricsExamples.java
@@ -113,7 +113,7 @@ public class MetricsExamples {
         routingContext.fail(500);
       }
     });
-    vertx.createHttpServer().requestHandler(router::accept).listen(8080);
+    vertx.createHttpServer().requestHandler(router).listen(8080);
   }
 
   public void setupMinimalJMX() {

--- a/src/main/java/io/vertx/micrometer/backends/InfluxDbBackendRegistry.java
+++ b/src/main/java/io/vertx/micrometer/backends/InfluxDbBackendRegistry.java
@@ -45,5 +45,6 @@ public final class InfluxDbBackendRegistry implements BackendRegistry {
 
   @Override
   public void close() {
+    registry.stop();
   }
 }

--- a/src/main/java/io/vertx/micrometer/backends/JmxBackendRegistry.java
+++ b/src/main/java/io/vertx/micrometer/backends/JmxBackendRegistry.java
@@ -43,5 +43,6 @@ public final class JmxBackendRegistry implements BackendRegistry {
 
   @Override
   public void close() {
+    registry.stop();
   }
 }

--- a/src/main/java/io/vertx/micrometer/backends/PrometheusBackendRegistry.java
+++ b/src/main/java/io/vertx/micrometer/backends/PrometheusBackendRegistry.java
@@ -64,7 +64,7 @@ public final class PrometheusBackendRegistry implements BackendRegistry {
         routingContext.response().end(response);
       });
       server = vertx.createHttpServer(serverOptions)
-        .requestHandler(router::accept)
+        .requestHandler(router)
         .exceptionHandler(t -> LOGGER.error("Error in Prometheus registry embedded server", t))
         .listen(serverOptions.getPort(), serverOptions.getHost());
     }

--- a/src/test/java/io/vertx/micrometer/VertxDatagramSocketMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxDatagramSocketMetricsTest.java
@@ -23,14 +23,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(VertxUnitRunner.class)
 public class VertxDatagramSocketMetricsTest {
 
+  private Vertx vertx;
+
   @After
-  public void teardown() {
-    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
   public void shouldReportDatagramMetrics(TestContext context) throws InterruptedException {
-    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
       .setEnabled(true)))
       .exceptionHandler(context.exceptionHandler());

--- a/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
@@ -28,14 +28,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(VertxUnitRunner.class)
 public class VertxEventBusMetricsTest {
 
+  private Vertx vertx;
+
   @After
-  public void teardown() {
-    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
   public void shouldReportEventbusMetrics(TestContext context) throws InterruptedException {
-    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
       .setEnabled(true)))
       .exceptionHandler(t -> {

--- a/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
@@ -9,13 +9,17 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.assertj.core.util.DoubleComparator;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
 
 import static io.vertx.micrometer.RegistryInspector.dp;
+import static io.vertx.micrometer.RegistryInspector.listDatapoints;
+import static io.vertx.micrometer.RegistryInspector.startsWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -23,6 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(VertxUnitRunner.class)
 public class VertxEventBusMetricsTest {
+
+  @After
+  public void teardown() {
+    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  }
 
   @Test
   public void shouldReportEventbusMetrics(TestContext context) throws InterruptedException {
@@ -75,8 +84,8 @@ public class VertxEventBusMetricsTest {
     vertx.eventBus().publish("testSubject", new JsonObject("{\"fail\": false, \"sleep\": 30, \"last\": true}"));
     allReceived.awaitSuccess();
 
-    List<RegistryInspector.Datapoint> datapoints = RegistryInspector.listWithoutTimers("vertx.eventbus.");
-    assertThat(datapoints).containsOnly(
+    List<RegistryInspector.Datapoint> datapoints = listDatapoints(startsWith("vertx.eventbus"));
+    assertThat(datapoints).hasSize(13).contains(
       dp("vertx.eventbus.handlers[address=testSubject]$VALUE", instances),
       dp("vertx.eventbus.pending[address=no handler,side=local]$VALUE", 0),
       dp("vertx.eventbus.pending[address=testSubject,side=local]$VALUE", 0),
@@ -86,15 +95,14 @@ public class VertxEventBusMetricsTest {
       dp("vertx.eventbus.received[address=testSubject,side=local]$COUNT", 8),
       dp("vertx.eventbus.delivered[address=testSubject,side=local]$COUNT", 8),
       dp("vertx.eventbus.replyFailures[address=no handler,failure=NO_HANDLERS]$COUNT", 2),
-      dp("vertx.eventbus.errors[address=testSubject,class=RuntimeException]$COUNT", 2 * instances));
+      dp("vertx.eventbus.errors[address=testSubject,class=RuntimeException]$COUNT", 2 * instances),
+      dp("vertx.eventbus.processingTime[address=testSubject]$COUNT", 8d * instances));
 
-    List<RegistryInspector.Datapoint> timersDp = RegistryInspector.listTimers("vertx.eventbus.");
-    assertThat(timersDp)
+    assertThat(datapoints)
       .usingFieldByFieldElementComparator()
       .usingComparatorForElementFieldsWithType(new DoubleComparator(1.0), Double.class)
-      .containsOnly(
+      .contains(
         dp("vertx.eventbus.processingTime[address=testSubject]$TOTAL_TIME", 180d * instances / 1000d),
-        dp("vertx.eventbus.processingTime[address=testSubject]$COUNT", 8d * instances),
         dp("vertx.eventbus.processingTime[address=testSubject]$MAX", 30d / 1000d));
   }
 }

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -78,12 +78,8 @@ public class VertxHttpClientServerMetricsTest {
   }
 
   @After
-  public void teardown() {
-    BackendRegistries.stop(registryName);
-    createdClients.forEach(HttpClient::close);
-    if (httpServer != null) {
-      httpServer.close();
-    }
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
@@ -10,6 +10,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,6 +22,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ForkJoinPool;
 
 import static io.vertx.micrometer.RegistryInspector.dp;
+import static io.vertx.micrometer.RegistryInspector.listDatapoints;
+import static io.vertx.micrometer.RegistryInspector.startsWith;
+import static io.vertx.micrometer.RegistryInspector.waitForValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -42,6 +46,7 @@ public class VertxNetClientServerMetricsTest {
   public void setUp(TestContext ctx) {
     vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+      .addDisabledMetricsCategory(MetricsDomain.EVENT_BUS)
       .setRegistryName(registryName)
       .setEnabled(true)))
       .exceptionHandler(ctx.exceptionHandler());
@@ -68,6 +73,7 @@ public class VertxNetClientServerMetricsTest {
 
   @After
   public void teardown() {
+    BackendRegistries.stop(registryName);
     createdClients.forEach(NetClient::close);
     if (netServer != null) {
       netServer.close();
@@ -78,10 +84,10 @@ public class VertxNetClientServerMetricsTest {
   public void shouldReportNetClientMetrics(TestContext ctx) throws InterruptedException {
     runClientRequests(ctx);
 
-    RegistryInspector.waitForValue(vertx, ctx, registryName, "vertx.net.client.bytesReceived[local=?,remote=localhost:9194]$COUNT",
+    waitForValue(vertx, ctx, registryName, "vertx.net.client.bytesReceived[local=?,remote=localhost:9194]$COUNT",
       value -> value.intValue() == concurrentClients * SENT_COUNT);
 
-    List<RegistryInspector.Datapoint> datapoints = RegistryInspector.listWithoutTimers("vertx.net.client.", registryName);
+    List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.net.client."));
     assertThat(datapoints).containsOnly(
         dp("vertx.net.client.connections[local=?,remote=localhost:9194]$VALUE", 0),
         dp("vertx.net.client.bytesReceived[local=?,remote=localhost:9194]$COUNT", concurrentClients * SENT_COUNT),
@@ -94,10 +100,10 @@ public class VertxNetClientServerMetricsTest {
   public void shouldReportHttpServerMetrics(TestContext ctx) throws InterruptedException {
     runClientRequests(ctx);
 
-    RegistryInspector.waitForValue(vertx, ctx, registryName, "vertx.net.server.bytesReceived[local=localhost:9194,remote=_]$COUNT",
+    waitForValue(vertx, ctx, registryName, "vertx.net.server.bytesReceived[local=localhost:9194,remote=_]$COUNT",
       value -> value.intValue() == concurrentClients * SENT_COUNT);
 
-    List<RegistryInspector.Datapoint> datapoints = RegistryInspector.listWithoutTimers("vertx.net.server.", registryName);
+    List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.net.server."));
     assertThat(datapoints).containsOnly(
       dp("vertx.net.server.connections[local=localhost:9194,remote=_]$VALUE", 0),
       dp("vertx.net.server.bytesReceived[local=localhost:9194,remote=_]$COUNT", concurrentClients * SENT_COUNT),

--- a/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
@@ -72,12 +72,8 @@ public class VertxNetClientServerMetricsTest {
   }
 
   @After
-  public void teardown() {
-    BackendRegistries.stop(registryName);
-    createdClients.forEach(NetClient::close);
-    if (netServer != null) {
-      netServer.close();
-    }
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/io/vertx/micrometer/VertxPoolMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxPoolMetricsTest.java
@@ -25,9 +25,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(VertxUnitRunner.class)
 public class VertxPoolMetricsTest {
 
+  private Vertx vertx;
+
   @After
-  public void teardown() {
-    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
@@ -36,7 +38,7 @@ public class VertxPoolMetricsTest {
     int taskCount = maxPoolSize * 3;
     int sleepMillis = 30;
 
-    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
       .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
       .setEnabled(true)))
       .exceptionHandler(context.exceptionHandler());

--- a/src/test/java/io/vertx/micrometer/VertxPoolMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxPoolMetricsTest.java
@@ -6,14 +6,17 @@ import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.assertj.core.util.DoubleComparator;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.vertx.micrometer.RegistryInspector.dp;
+import static io.vertx.micrometer.RegistryInspector.listDatapoints;
+import static io.vertx.micrometer.RegistryInspector.startsWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -21,6 +24,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(VertxUnitRunner.class)
 public class VertxPoolMetricsTest {
+
+  @After
+  public void teardown() {
+    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  }
 
   @Test
   public void shouldReportNamedPoolMetrics(TestContext context) throws InterruptedException {
@@ -54,23 +62,18 @@ public class VertxPoolMetricsTest {
       "vertx.pool.completed[pool_name=test-worker,pool_type=worker]$COUNT",
       value -> value.intValue() == taskCount);
 
-    List<RegistryInspector.Datapoint> datapoints = RegistryInspector.listWithoutTimers("vertx.pool.");
-    assertThat(datapoints).containsOnly(
+    List<RegistryInspector.Datapoint> datapoints = listDatapoints(startsWith("vertx.pool"));
+    assertThat(datapoints).hasSize(10).contains(
       dp("vertx.pool.queue.size[pool_name=test-worker,pool_type=worker]$VALUE", 0),
       dp("vertx.pool.inUse[pool_name=test-worker,pool_type=worker]$VALUE", 0),
       dp("vertx.pool.ratio[pool_name=test-worker,pool_type=worker]$VALUE", 0),
-      dp("vertx.pool.completed[pool_name=test-worker,pool_type=worker]$COUNT", taskCount));
+      dp("vertx.pool.completed[pool_name=test-worker,pool_type=worker]$COUNT", taskCount),
+      dp("vertx.pool.queue.delay[pool_name=test-worker,pool_type=worker]$COUNT", taskCount),
+      dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$COUNT", taskCount));
 
-    List<RegistryInspector.Datapoint> timersDp = RegistryInspector.listTimers("vertx.pool.")
-      .stream().filter(dp -> dp.id().startsWith("vertx.pool.")).collect(Collectors.toList());
-    assertThat(timersDp).hasSize(6)
-      .contains(
-        dp("vertx.pool.queue.delay[pool_name=test-worker,pool_type=worker]$COUNT", taskCount),
-        dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$COUNT", taskCount));
-
-    assertThat(timersDp)
+    assertThat(datapoints)
       .usingFieldByFieldElementComparator()
-      .usingComparatorForElementFieldsWithType(new DoubleComparator(1.0), Double.class)
+      .usingComparatorForElementFieldsWithType(new DoubleComparator(0.1), Double.class)
       .contains(
         dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$TOTAL_TIME", taskCount * sleepMillis / 1000d),
         dp("vertx.pool.usage[pool_name=test-worker,pool_type=worker]$MAX", sleepMillis / 1000d));

--- a/src/test/java/io/vertx/micrometer/VertxVerticleMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxVerticleMetricsTest.java
@@ -7,6 +7,8 @@ import io.vertx.core.VertxOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.micrometer.backends.BackendRegistries;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -14,6 +16,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.vertx.micrometer.RegistryInspector.dp;
+import static io.vertx.micrometer.RegistryInspector.listDatapoints;
+import static io.vertx.micrometer.RegistryInspector.startsWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -21,6 +25,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(VertxUnitRunner.class)
 public class VertxVerticleMetricsTest {
+
+  @After
+  public void teardown() {
+    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  }
 
   @Test
   public void shouldReportVerticleMetrics(TestContext context) throws InterruptedException {
@@ -43,7 +52,7 @@ public class VertxVerticleMetricsTest {
     });
     async1.awaitSuccess();
 
-    List<RegistryInspector.Datapoint> datapoints = RegistryInspector.listWithoutTimers("vertx.verticle");
+    List<RegistryInspector.Datapoint> datapoints = listDatapoints(startsWith("vertx.verticle."));
     assertThat(datapoints).containsOnly(
       dp(metricName + "$VALUE", 3));
 
@@ -57,7 +66,7 @@ public class VertxVerticleMetricsTest {
     });
     async2.awaitSuccess();
 
-    datapoints = RegistryInspector.listWithoutTimers("vertx.verticle");
+    datapoints = listDatapoints(startsWith("vertx.verticle"));
     assertThat(datapoints).containsOnly(
       dp(metricName + "$VALUE", 7));
 
@@ -71,7 +80,7 @@ public class VertxVerticleMetricsTest {
     });
     async3.awaitSuccess();
 
-    datapoints = RegistryInspector.listWithoutTimers("vertx.verticle");
+    datapoints = listDatapoints(startsWith("vertx.verticle"));
     assertThat(datapoints).containsOnly(
       dp(metricName + "$VALUE", 4));
   }

--- a/src/test/java/io/vertx/micrometer/VertxVerticleMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxVerticleMetricsTest.java
@@ -26,16 +26,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(VertxUnitRunner.class)
 public class VertxVerticleMetricsTest {
 
+  private Vertx vertx;
+
   @After
-  public void teardown() {
-    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
   public void shouldReportVerticleMetrics(TestContext context) throws InterruptedException {
     String metricName = "vertx.verticle.deployed[class=" + SampleVerticle.class.getName() + "]";
 
-    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
       .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
       .setEnabled(true)))
       .exceptionHandler(context.exceptionHandler());

--- a/src/test/java/io/vertx/micrometer/backend/CustomMicrometerMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/CustomMicrometerMetricsITest.java
@@ -28,7 +28,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,11 +43,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CustomMicrometerMetricsITest {
 
   private static final String REGITRY_NAME = "CustomMicrometerMetricsITest";
+  private Vertx vertx;
   private Vertx vertxForSimulatedServer = Vertx.vertx();
 
   @After
   public void after(TestContext context) {
-    BackendRegistries.stop(REGITRY_NAME);
+    vertx.close(context.asyncAssertSuccess());
     vertxForSimulatedServer.close(context.asyncAssertSuccess());
   }
 
@@ -86,7 +86,7 @@ public class CustomMicrometerMetricsITest {
       }
     }, Clock.SYSTEM));
 
-    Vertx vertx = Vertx.vertx(new VertxOptions()
+    vertx = Vertx.vertx(new VertxOptions()
       .setMetricsOptions(new MicrometerMetricsOptions()
         .setMicrometerRegistry(myRegistry)
         .setRegistryName(REGITRY_NAME)

--- a/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
@@ -24,7 +24,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxInfluxDbOptions;
-import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,11 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class InfluxDbReporterITest {
 
   private static final String REGITRY_NAME = "InfluxDbReporterITest";
+  private Vertx vertx;
   private Vertx vertxForSimulatedServer = Vertx.vertx();
 
   @After
   public void after(TestContext context) {
-    BackendRegistries.stop(REGITRY_NAME);
+    vertx.close(context.asyncAssertSuccess());
     vertxForSimulatedServer.close(context.asyncAssertSuccess());
   }
 
@@ -56,7 +56,7 @@ public class InfluxDbReporterITest {
       }
     });
 
-    Vertx vertx = Vertx.vertx(new VertxOptions()
+    vertx = Vertx.vertx(new VertxOptions()
       .setMetricsOptions(new MicrometerMetricsOptions()
         .setInfluxDbOptions(new VertxInfluxDbOptions()
           .setStep(1)

--- a/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
@@ -24,8 +24,8 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxInfluxDbOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,35 +34,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(VertxUnitRunner.class)
 public class InfluxDbReporterITest {
 
-  private Vertx vertx;
-
-  @Before
-  public void setUp(TestContext context) {
-    vertx = Vertx.vertx(new VertxOptions()
-      .setMetricsOptions(new MicrometerMetricsOptions()
-        .setInfluxDbOptions(new VertxInfluxDbOptions()
-          .setStep(1)
-          .setEnabled(true))
-        .setRegistryName("influx")
-        .setEnabled(true)));
-  }
+  private static final String REGITRY_NAME = "InfluxDbReporterITest";
+  private Vertx vertxForSimulatedServer = Vertx.vertx();
 
   @After
   public void after(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
+    BackendRegistries.stop(REGITRY_NAME);
+    vertxForSimulatedServer.close(context.asyncAssertSuccess());
   }
 
   @Test
-  public void shouldSendDataToInfluxDb(TestContext context) {
-    Async async = context.async();
-    InfluxDbTestHelper.simulateInfluxServer(vertx, context, 8086, body -> {
+  public void shouldSendDataToInfluxDb(TestContext context) throws Exception {
+    // Mock an influxdb server
+    Async asyncInflux = context.async();
+    InfluxDbTestHelper.simulateInfluxServer(vertxForSimulatedServer, context, 8086, body -> {
       try {
-        context.verify(v -> assertThat(body)
-          .contains("vertx_http_server_connections,local=localhost:8086,remote=_,metric_type=gauge value=1"));
+        context.verify(w -> assertThat(body)
+          .contains("vertx_eventbus_handlers,address=test-eb,metric_type=gauge value=1"));
       } finally {
-        async.complete();
+        asyncInflux.complete();
       }
     });
-    async.awaitSuccess();
+
+    Vertx vertx = Vertx.vertx(new VertxOptions()
+      .setMetricsOptions(new MicrometerMetricsOptions()
+        .setInfluxDbOptions(new VertxInfluxDbOptions()
+          .setStep(1)
+          .setDb("mydb")
+          .setEnabled(true))
+        .setRegistryName(REGITRY_NAME)
+        .setEnabled(true)));
+
+    // Send something on the eventbus and wait til it's received
+    Async asyncEB = context.async();
+    vertx.eventBus().consumer("test-eb", msg -> asyncEB.complete());
+    vertx.eventBus().publish("test-eb", "test message");
+    asyncEB.await(2000);
+
+    // Await influx
+    asyncInflux.awaitSuccess();
   }
 }

--- a/src/test/java/io/vertx/micrometer/backend/JmxMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/JmxMetricsITest.java
@@ -37,18 +37,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(VertxUnitRunner.class)
 public class JmxMetricsITest {
 
-  private Vertx vertx;
+  private static final String REGISTRY_NAME = "jmx-test";
 
   @After
   public void tearDown() {
-    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+    BackendRegistries.stop(REGISTRY_NAME);
   }
 
   @Test
   public void shouldReportJmx(TestContext context) throws Exception {
-    vertx = Vertx.vertx(new VertxOptions()
+    Vertx vertx = Vertx.vertx(new VertxOptions()
       .setMetricsOptions(new MicrometerMetricsOptions()
+        .setRegistryName(REGISTRY_NAME)
         .setJmxMetricsOptions(new VertxJmxMetricsOptions().setEnabled(true)
+          .setDomain("my-metrics")
           .setStep(1))
         .setEnabled(true)));
 
@@ -60,8 +62,8 @@ public class JmxMetricsITest {
 
     // Read MBean
     MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-    assertThat(mbs.getDomains()).contains("metrics");
-    Number result = (Number) mbs.getAttribute(new ObjectName("metrics", "name", "vertxEventbusHandlers.address.test-eb"), "Value");
+    assertThat(mbs.getDomains()).contains("my-metrics");
+    Number result = (Number) mbs.getAttribute(new ObjectName("my-metrics", "name", "vertxEventbusHandlers.address.test-eb"), "Value");
     assertThat(result).isEqualTo(1d);
   }
 }

--- a/src/test/java/io/vertx/micrometer/backend/JmxMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/JmxMetricsITest.java
@@ -23,7 +23,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxJmxMetricsOptions;
-import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,15 +37,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JmxMetricsITest {
 
   private static final String REGISTRY_NAME = "jmx-test";
+  private Vertx vertx;
 
   @After
-  public void tearDown() {
-    BackendRegistries.stop(REGISTRY_NAME);
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
   public void shouldReportJmx(TestContext context) throws Exception {
-    Vertx vertx = Vertx.vertx(new VertxOptions()
+    vertx = Vertx.vertx(new VertxOptions()
       .setMetricsOptions(new MicrometerMetricsOptions()
         .setRegistryName(REGISTRY_NAME)
         .setJmxMetricsOptions(new VertxJmxMetricsOptions().setEnabled(true)

--- a/src/test/java/io/vertx/micrometer/backend/PrometheusMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/PrometheusMetricsITest.java
@@ -78,7 +78,7 @@ public class PrometheusMetricsITest {
       String response = prometheusRegistry.scrape();
       routingContext.response().end(response);
     });
-    vertx.createHttpServer().requestHandler(router::accept).listen(8081);
+    vertx.createHttpServer().requestHandler(router).listen(8081);
 
     Async async = context.async();
     HttpClientRequest req = vertx.createHttpClient()

--- a/src/test/java/io/vertx/micrometer/backend/PrometheusMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/PrometheusMetricsITest.java
@@ -43,8 +43,8 @@ public class PrometheusMetricsITest {
   private Vertx vertx;
 
   @After
-  public void tearDown() {
-    BackendRegistries.stop(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
+++ b/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
@@ -63,10 +63,8 @@ public class MetricsServiceImplTest {
   }
 
   @After
-  public void teardown() {
-    if (httpServer != null) {
-      httpServer.close();
-    }
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test


### PR DESCRIPTION
…stopping registry push jobs

- It may fix issue #25 (bug not reproduced until now)
- better cleaning in tests (release registries after use), and fixing several side-effect exceptions in tests that were not affecting results (such as never-canceled timer)
- Influx and JMX registries now correctly stopped