### PR TITLE
Prometheus backend: do not create a vertx object if not necessary

### DIFF
--- a/src/main/java/io/vertx/micrometer/backends/PrometheusBackendRegistry.java
+++ b/src/main/java/io/vertx/micrometer/backends/PrometheusBackendRegistry.java
@@ -33,11 +33,10 @@ public final class PrometheusBackendRegistry implements BackendRegistry {
   private static final Logger LOGGER = LoggerFactory.getLogger(PrometheusBackendRegistry.class);
 
   private final PrometheusMeterRegistry registry;
-  private final Vertx vertx;
   private final VertxPrometheusOptions options;
+  private Vertx vertx;
 
   public PrometheusBackendRegistry(VertxPrometheusOptions options) {
-    this.vertx = Vertx.vertx();
     this.options = options;
     registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
   }
@@ -50,6 +49,7 @@ public final class PrometheusBackendRegistry implements BackendRegistry {
   @Override
   public void init() {
     if (options.isStartEmbeddedServer()) {
+      this.vertx = Vertx.vertx();
       // Start dedicated server
       HttpServerOptions serverOptions = options.getEmbeddedServerOptions();
       if (serverOptions == null) {
@@ -69,6 +69,8 @@ public final class PrometheusBackendRegistry implements BackendRegistry {
 
   @Override
   public void close() {
-    vertx.close();
+    if (this.vertx != null) {
+      vertx.close();
+    }
   }
 }


### PR DESCRIPTION
@vietj this is a small optimization following your commit https://github.com/vert-x3/vertx-micrometer-metrics/commit/53f9789ee7b444f89d4592d466fa11bf575362b0