### PR TITLE
[#41] Provide HTTP Method key in all the relevant VertxHttpServerMetrics 

### DIFF
--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
@@ -42,10 +42,10 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
 
   VertxHttpServerMetrics(MeterRegistry registry) {
     super(registry, MetricsDomain.HTTP_SERVER);
-    requests = longGauges("requests", "Number of requests being processed", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH);
+    requests = longGauges("requests", "Number of requests being processed", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     requestCount = counters("requestCount", "Number of processed requests", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE);
-    requestResetCount = counters("requestResetCount", "Number of requests reset", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH);
-    processingTime = timers("responseTime", "Request processing time", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH);
+    requestResetCount = counters("requestResetCount", "Number of requests reset", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH,Label.HTTP_METHOD);
+    processingTime = timers("responseTime", "Request processing time", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     wsConnections = longGauges("wsConnections", "Number of websockets currently opened", Label.LOCAL, Label.REMOTE);
   }
 
@@ -63,21 +63,21 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     @Override
     public Handler requestBegin(String remote, HttpServerRequest request) {
       Handler handler = new Handler(remote, request.path(), request.method().name());
-      requests.get(local, remote, handler.path).increment();
-      handler.timer = processingTime.start(local, remote, handler.path);
+      requests.get(local, handler.address, handler.path, handler.method).increment();
+      handler.timer = processingTime.start(local, remote, handler.path,handler.method);
       return handler;
     }
 
     @Override
     public void requestReset(Handler handler) {
-      requestResetCount.get(local, handler.address, handler.path).increment();
-      requests.get(local, handler.address, handler.path).decrement();
+      requestResetCount.get(local, handler.address, handler.path,handler.method).increment();
+      requests.get(local, handler.address, handler.path, handler.method).decrement();
     }
 
     @Override
     public Handler responsePushed(String remote, HttpMethod method, String uri, HttpServerResponse response) {
       Handler handler = new Handler(remote, uri, method.name());
-      requests.get(local, remote, handler.path).increment();
+      requests.get(local, handler.address, handler.path, handler.method).increment();
       return handler;
     }
 
@@ -85,7 +85,7 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     public void responseEnd(Handler handler, HttpServerResponse response) {
       handler.timer.end();
       requestCount.get(local, handler.address, handler.path, handler.method, String.valueOf(response.getStatusCode())).increment();
-      requests.get(local, handler.address, handler.path).decrement();
+      requests.get(local, handler.address, handler.path, handler.method).decrement();
     }
 
     @Override

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
@@ -63,7 +63,7 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     @Override
     public Handler requestBegin(String remote, HttpServerRequest request) {
       Handler handler = new Handler(remote, request.path(), request.method().name());
-      requests.get(local, handler.address, handler.path, handler.method).increment();
+      requests.get(local, remote, handler.path, handler.method).increment();
       handler.timer = processingTime.start(local, remote, handler.path,handler.method);
       return handler;
     }
@@ -77,7 +77,7 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     @Override
     public Handler responsePushed(String remote, HttpMethod method, String uri, HttpServerResponse response) {
       Handler handler = new Handler(remote, uri, method.name());
-      requests.get(local, handler.address, handler.path, handler.method).increment();
+      requests.get(local, remote, handler.path, handler.method).increment();
       return handler;
     }
 

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
@@ -44,7 +44,7 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     super(registry, MetricsDomain.HTTP_SERVER);
     requests = longGauges("requests", "Number of requests being processed", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     requestCount = counters("requestCount", "Number of processed requests", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE);
-    requestResetCount = counters("requestResetCount", "Number of requests reset", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH,Label.HTTP_METHOD);
+    requestResetCount = counters("requestResetCount", "Number of requests reset", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     processingTime = timers("responseTime", "Request processing time", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     wsConnections = longGauges("wsConnections", "Number of websockets currently opened", Label.LOCAL, Label.REMOTE);
   }

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -117,16 +117,16 @@ public class VertxHttpClientServerMetricsTest {
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).containsOnly(
       "vertx.http.server.requestCount[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.requests[local=127.0.0.1:9195,path=/resource,remote=_]$VALUE",
+      "vertx.http.server.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$VALUE",
       "vertx.http.server.connections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.wsConnections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
       "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$TOTAL",
       "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT",
       "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$TOTAL",
-      "vertx.http.server.responseTime[local=127.0.0.1:9195,path=/resource,remote=_]$TOTAL_TIME",
-      "vertx.http.server.responseTime[local=127.0.0.1:9195,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.responseTime[local=127.0.0.1:9195,path=/resource,remote=_]$MAX");
+      "vertx.http.server.responseTime[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL_TIME",
+      "vertx.http.server.responseTime[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
+      "vertx.http.server.responseTime[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$MAX");
 
     assertThat(datapoints).contains(
       dp("vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * SENT_COUNT),

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -102,9 +102,12 @@ public class VertxHttpClientServerMetricsTest {
         dp("vertx.http.client.requestCount[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT));
 
     assertThat(datapoints).extracting(Datapoint::id).contains(
-      "vertx.http.client.responseTime[local=?,path=/resource,remote=127.0.0.1:9195]$TOTAL_TIME",
-      "vertx.http.client.responseTime[local=?,path=/resource,remote=127.0.0.1:9195]$COUNT",
-      "vertx.http.client.responseTime[local=?,path=/resource,remote=127.0.0.1:9195]$MAX");
+      "vertx.http.client.responseTime[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$TOTAL_TIME",
+      "vertx.http.client.responseTime[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT",
+      "vertx.http.client.responseTime[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$MAX",
+      "vertx.http.client.requests[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$VALUE",
+      "vertx.http.client.responseCount[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT",
+      "vertx.http.client.connections[local=?,remote=127.0.0.1:9195]$VALUE");
   }
 
   @Test


### PR DESCRIPTION
Add Label.Method for following Vertx HTTP server metrics. The PR fixes https://github.com/vert-x3/vertx-micrometer-metrics/issues/41. 
 - requests
 - requestResetCount
 - responseTime