### PR TITLE
Increment responseCount counter

### DIFF
--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
@@ -115,7 +115,7 @@ class VertxHttpClientMetrics extends VertxNetClientMetrics {
     @Override
     public void responseEnd(Handler handler, HttpClientResponse response) {
       requests.get(local, handler.address, handler.path, handler.method).decrement();
-      responseCount.get(local, handler.address, handler.path, String.valueOf(response.statusCode()), handler.method);
+      responseCount.get(local, handler.address, handler.path, String.valueOf(response.statusCode()), handler.method).increment();
       handler.timer.end();
     }
 

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -99,14 +99,14 @@ public class VertxHttpClientServerMetricsTest {
         dp("vertx.http.client.bytesReceived[local=?,remote=127.0.0.1:9195]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
         dp("vertx.http.client.bytesSent[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
         dp("vertx.http.client.bytesSent[local=?,remote=127.0.0.1:9195]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-        dp("vertx.http.client.requestCount[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT));
+        dp("vertx.http.client.requestCount[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+        dp("vertx.http.client.responseCount[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT));
 
     assertThat(datapoints).extracting(Datapoint::id).contains(
       "vertx.http.client.responseTime[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$TOTAL_TIME",
       "vertx.http.client.responseTime[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT",
       "vertx.http.client.responseTime[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$MAX",
       "vertx.http.client.requests[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$VALUE",
-      "vertx.http.client.responseCount[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT",
       "vertx.http.client.connections[local=?,remote=127.0.0.1:9195]$VALUE");
   }
 


### PR DESCRIPTION
The counters for "responseCount" are retrieved but never incremented.
I dont know if this should also be backported to the 3.5 branch.