### PR TITLE
Add option flag to publish quantiles for Prometheus

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -176,6 +176,10 @@ HTTP server options for the embedded server
 |[[enabled]]`@enabled`|`Boolean`|+++
 Set true to enable Prometheus reporting
 +++
+|[[publishQuantiles]]`@publishQuantiles`|`Boolean`|+++
+Set true to publish histogram stats, necessary to compute quantiles.
+ Note that it generates many new timeseries for stats, which is why it is deactivated by default.
++++
 |[[startEmbeddedServer]]`@startEmbeddedServer`|`Boolean`|+++
 When true, an embedded server will init to expose metrics with Prometheus format.
 +++

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -211,24 +211,37 @@ with `promql`. Example, for HTTP client response time average during the last 5 
   rate(vertx_http_client_responseTime_seconds_count[5m])
 ----
 
-To get quantiles, some additional configuration is needed in Micrometer registry config, as link:https://micrometer.io/docs/concepts#_histograms_and_percentiles[explained here].
-
-For example, here's how to activate percentile stats globally:
+To compute quantiles, there are two options available. The first is to activate quantile stats globally
+and make them usable for Prometheus function `histogram_quantile`:
 
 [source,$lang]
 ----
-{@link examples.MicrometerMetricsExamples#enablePercentiles()}
+{@link examples.MicrometerMetricsExamples#enableQuantiles()}
 ----
 
-And then, the `promql` query for the HTTP client response time, 99th percentile over the last 5 minutes:
+And then, for example the `promql` query for the HTTP client response time, 99th percentile over the last 5 minutes:
 [source]
 ----
   histogram_quantile(0.99, sum(rate(vertx_http_client_responseTime_seconds_bucket[5m])) by (le))
 ----
 
-See also link:https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile[Prometheus doc].
+The advantage of this option is that it can be leveraged in `promql`, aggregable across dimensions.
+The downside is that it creates a lot of timeseries for stats under the hood.
 
-You can also check some link:https://github.com/vert-x3/vertx-examples/tree/master/micrometer-metrics-examples[full working examples].
+The second option is to create limited stats, non-aggregable across dimensions.
+It requires to access directly the Micrometer / Prometheus registry:
+
+[source,$lang]
+----
+{@link examples.MicrometerMetricsExamples#enableLimitedQuantiles()}
+----
+
+See also, more on histograms and percentiles:
+
+* from link:https://micrometer.io/docs/concepts#_histograms_and_percentiles[Micrometer doc]
+* from link:https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile[Prometheus doc]
+
+Furthermore, you can check some link:https://github.com/vert-x3/vertx-examples/tree/master/micrometer-metrics-examples[full working examples].
 They come along with few instructions to setup with Prometheus and view dashboards in Grafana.
 
 === Disable some metric domains

--- a/src/main/generated/io/vertx/micrometer/VertxPrometheusOptionsConverter.java
+++ b/src/main/generated/io/vertx/micrometer/VertxPrometheusOptionsConverter.java
@@ -29,6 +29,11 @@ public class VertxPrometheusOptionsConverter {
             obj.setEnabled((Boolean)member.getValue());
           }
           break;
+        case "publishQuantiles":
+          if (member.getValue() instanceof Boolean) {
+            obj.setPublishQuantiles((Boolean)member.getValue());
+          }
+          break;
         case "startEmbeddedServer":
           if (member.getValue() instanceof Boolean) {
             obj.setStartEmbeddedServer((Boolean)member.getValue());
@@ -50,6 +55,7 @@ public class VertxPrometheusOptionsConverter {
       json.put("embeddedServerOptions", obj.getEmbeddedServerOptions().toJson());
     }
     json.put("enabled", obj.isEnabled());
+    json.put("publishQuantiles", obj.isPublishQuantiles());
     json.put("startEmbeddedServer", obj.isStartEmbeddedServer());
   }
 }

--- a/src/main/java/examples/MicrometerMetricsExamples.java
+++ b/src/main/java/examples/MicrometerMetricsExamples.java
@@ -225,14 +225,22 @@ public class MicrometerMetricsExamples {
         .setEnabled(true)));
   }
 
-  public void enablePercentiles() {
+  public void enableQuantiles() {
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+      new MicrometerMetricsOptions()
+        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true)
+          .setPublishQuantiles(true))
+        .setEnabled(true)));
+  }
+
+  public void enableLimitedQuantiles() {
     PrometheusMeterRegistry registry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
     registry.config().meterFilter(
         new MeterFilter() {
           @Override
           public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
             return DistributionStatisticConfig.builder()
-                .percentilesHistogram(true)
+                .percentiles(0.95, 0.99)
                 .build()
                 .merge(config);
           }

--- a/src/main/java/io/vertx/micrometer/VertxPrometheusOptions.java
+++ b/src/main/java/io/vertx/micrometer/VertxPrometheusOptions.java
@@ -43,10 +43,16 @@ public class VertxPrometheusOptions {
    */
   public static final String DEFAULT_EMBEDDED_SERVER_ENDPOINT = "/metrics";
 
+  /**
+   * Default value for publishing histogram quantiles = false.
+   */
+  public static final boolean DEFAULT_PUBLISH_QUANTILES = false;
+
   private boolean enabled;
   private boolean startEmbeddedServer;
   private HttpServerOptions embeddedServerOptions;
   private String embeddedServerEndpoint;
+  private boolean publishQuantiles;
 
   /**
    * Default constructor
@@ -55,6 +61,7 @@ public class VertxPrometheusOptions {
     enabled = DEFAULT_ENABLED;
     startEmbeddedServer = DEFAULT_START_EMBEDDED_SERVER;
     embeddedServerEndpoint = DEFAULT_EMBEDDED_SERVER_ENDPOINT;
+    publishQuantiles = DEFAULT_PUBLISH_QUANTILES;
   }
 
   /**
@@ -69,6 +76,7 @@ public class VertxPrometheusOptions {
     if (other.embeddedServerOptions != null) {
       embeddedServerOptions = new HttpServerOptions(other.embeddedServerOptions);
     }
+    publishQuantiles = other.publishQuantiles;
   }
 
   /**
@@ -153,5 +161,24 @@ public class VertxPrometheusOptions {
    */
   public String getEmbeddedServerEndpoint() {
     return embeddedServerEndpoint;
+  }
+
+  /**
+   * @return true if quantile stats are published
+   */
+  public boolean isPublishQuantiles() {
+    return publishQuantiles;
+  }
+
+  /**
+   * Set true to publish histogram stats, necessary to compute quantiles.
+   * Note that it generates many new timeseries for stats, which is why it is deactivated by default.
+   *
+   * @param publishQuantiles the publishing quantiles flag
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxPrometheusOptions setPublishQuantiles(boolean publishQuantiles) {
+    this.publishQuantiles = publishQuantiles;
+    return this;
   }
 }

--- a/src/main/java/io/vertx/micrometer/backends/PrometheusBackendRegistry.java
+++ b/src/main/java/io/vertx/micrometer/backends/PrometheusBackendRegistry.java
@@ -16,7 +16,10 @@
  */
 package io.vertx.micrometer.backends;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
@@ -41,6 +44,18 @@ public final class PrometheusBackendRegistry implements BackendRegistry {
   public PrometheusBackendRegistry(VertxPrometheusOptions options) {
     this.options = options;
     registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    if (options.isPublishQuantiles()) {
+      registry.config().meterFilter(
+        new MeterFilter() {
+          @Override
+          public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+            return DistributionStatisticConfig.builder()
+              .percentilesHistogram(true)
+              .build()
+              .merge(config);
+          }
+        });
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes #22 , fixes #52 

- new boolean flag publishQuantiles in VertxPrometheusOptions. If not enabled, summary and timer metrics (such as response times) will not include bucket stats to allow histogram-quantiles querying
- update examples and documentation

Add more examples in documentation