### PR TITLE
reverse condiditional check for configuring Prometheus backend

### DIFF
--- a/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
+++ b/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
@@ -58,7 +58,7 @@ public final class BackendRegistries {
     return REGISTRIES.computeIfAbsent(options.getRegistryName(), k -> {
       final BackendRegistry reg;
       if (options.getMicrometerRegistry() != null) {
-        if (options.getMicrometerRegistry() instanceof PrometheusMeterRegistry && options.getPrometheusOptions() != null) {
+        if (options.getPrometheusOptions() != null && options.getMicrometerRegistry() instanceof PrometheusMeterRegistry) {
           // If a Prometheus registry is provided, extra initialization steps may have to be performed
           reg = new PrometheusBackendRegistry(options.getPrometheusOptions(), (PrometheusMeterRegistry) options.getMicrometerRegistry());
         } else {


### PR DESCRIPTION
Having a check of `instanceof` before `#getPrometheusOptions` causes
code using other backend registry throw no class defined exception:

```
java.lang.NoClassDefFoundError: io/micrometer/prometheus/PrometheusMeterRegistry
```

Reversing this condition fixes the issue due to both short-circuiting and lazy class loading.

Generally `instanceof` branch can be removed at all as 2nd PrometheusBackendRegistry constructor
does nothing else than setting generic prometheus options that could be done in:

https://github.com/vert-x3/vertx-micrometer-metrics/blob/74d70d238d1c160318bbf5f558c39e64af74b679/src/main/java/io/vertx/micrometer/backends/PrometheusBackendRegistry.java#L51

Original issue reference: https://github.com/vert-x3/vertx-micrometer-metrics/issues/79