### PR TITLE
Fix acceptance matchers ineffective

### DIFF
--- a/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
+++ b/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
@@ -125,13 +125,13 @@ public final class BackendRegistries {
         case EQUALS:
           if (m.getAlias() == null) {
             // Exact match => accept
-            registry.config().meterFilter(MeterFilter.accept(id -> {
+            registry.config().meterFilter(MeterFilter.deny(id -> {
               if (m.getDomain() != null && !id.getName().startsWith(m.getDomain().getPrefix())) {
                 // If domain has been specified and we're not in that domain, ignore rule
-                return true;
+                return false;
               }
               String tagValue = id.getTag(m.getLabel());
-              return m.getValue().equals(tagValue);
+              return !m.getValue().equals(tagValue);
             }));
           } else {
             // Exact match => alias

--- a/src/test/java/io/vertx/micrometer/MatchersTest.java
+++ b/src/test/java/io/vertx/micrometer/MatchersTest.java
@@ -1,0 +1,78 @@
+package io.vertx.micrometer;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.micrometer.backends.BackendRegistries;
+import io.vertx.micrometer.impl.meters.Counters;
+import org.assertj.core.util.DoubleComparator;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+
+import static io.vertx.micrometer.RegistryInspector.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Joel Takvorian
+ */
+@RunWith(VertxUnitRunner.class)
+public class MatchersTest {
+
+  @Test
+  public void shouldFilterMetric() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+    BackendRegistries.registerMatchers(registry, EnumSet.allOf(Label.class), Collections.singletonList(new Match()
+      .setLabel("address")
+      .setType(MatchType.EQUALS)
+      .setValue("addr1")));
+    Counters counters = new Counters("my_counter", "", registry, Label.EB_ADDRESS);
+    counters.get("addr1").increment();
+    counters.get("addr2").increment();
+
+    Counter c = registry.find("my_counter").tags("address", "addr1").counter();
+    assertThat(c.count()).isEqualTo(1d);
+    c = registry.find("my_counter").tags("address", "addr2").counter();
+    assertThat(c).isNull();
+  }
+
+  @Test
+  public void shouldFilterDomainMetric() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+    BackendRegistries.registerMatchers(registry, EnumSet.allOf(Label.class), Collections.singletonList(new Match()
+      .setLabel("address")
+      .setDomain(MetricsDomain.EVENT_BUS)
+      .setType(MatchType.EQUALS)
+      .setValue("addr1")));
+    String metric1 = MetricsDomain.EVENT_BUS.getPrefix() + "_counter";
+    Counters counters1 = new Counters(metric1, "", registry, Label.EB_ADDRESS);
+    counters1.get("addr1").increment();
+    counters1.get("addr2").increment();
+    String metric2 = "another_domain_counter";
+    Counters counters2 = new Counters(metric2, "", registry, Label.EB_ADDRESS);
+    counters2.get("addr1").increment();
+    counters2.get("addr2").increment();
+
+    // In domain where the rule applies, filter is performed
+    Counter c = registry.find(metric1).tags("address", "addr1").counter();
+    assertThat(c.count()).isEqualTo(1d);
+    c = registry.find(metric1).tags("address", "addr2").counter();
+    assertThat(c).isNull();
+    // In other domain, no filter
+    c = registry.find(metric2).tags("address", "addr1").counter();
+    assertThat(c.count()).isEqualTo(1d);
+    c = registry.find(metric2).tags("address", "addr2").counter();
+    assertThat(c.count()).isEqualTo(1d);
+  }
+}


### PR DESCRIPTION
Need to reverse logic and use "deny" instead of "accept" ; "accept" only is useful to shortcut next filters processing but will not be useful to filter out metrics (unless they're explicitly said to be all denied by default)

Added a test

Fixes https://github.com/vert-x3/vertx-micrometer-metrics/issues/92
