### PR TITLE
Change EB processingTime to processed counter, remove errors counter (breaking changes)

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -607,11 +607,6 @@ depending on the backend used.
 |Gauge
 |Number of event bus handlers in use.
 
-|`vertx_eventbus_errors`
-|`address`,`class`
-|Counter
-|Number of errors.
-
 |`vertx_eventbus_bytesWritten`
 |`address`
 |Summary
@@ -627,6 +622,11 @@ depending on the backend used.
 |Gauge
 |Number of messages not processed yet. One message published will count for `N` pending if `N` handlers
 are registered to the corresponding address.
+
+|`vertx_eventbus_processed`
+|`address`,`side` (local/remote)
+|Counter
+|Number of processed messages.
 
 |`vertx_eventbus_published`
 |`address`,`side` (local/remote)
@@ -652,11 +652,6 @@ are registered to the corresponding address.
 |`address`,`failure`
 |Counter
 |Number of message reply failures.
-
-|`vertx_eventbus_processingTime`
-|`address`
-|Timer
-|Processing time for handlers listening to the `address`.
 
 |===
 

--- a/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
@@ -1,26 +1,17 @@
 package io.vertx.micrometer;
 
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.assertj.core.util.DoubleComparator;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
 
-import static io.vertx.micrometer.RegistryInspector.dp;
-import static io.vertx.micrometer.RegistryInspector.listDatapoints;
-import static io.vertx.micrometer.RegistryInspector.startsWith;
-import static io.vertx.micrometer.RegistryInspector.waitForValue;
+import static io.vertx.micrometer.RegistryInspector.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -37,7 +28,7 @@ public class VertxEventBusMetricsTest {
   }
 
   @Test
-  public void shouldReportEventbusMetrics(TestContext context) throws InterruptedException {
+  public void shouldReportEventbusMetrics(TestContext context) {
     vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
       .addLabels(Label.EB_ADDRESS, Label.EB_FAILURE, Label.CLASS_NAME)
@@ -55,7 +46,7 @@ public class VertxEventBusMetricsTest {
     // Setup eventbus handler
     vertx.deployVerticle(() -> new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> future) throws Exception {
+      public void start(Promise<Void> future) {
         vertx.eventBus().consumer("testSubject", msg -> {
           JsonObject body = (JsonObject) msg.body();
           try {
@@ -88,10 +79,10 @@ public class VertxEventBusMetricsTest {
     vertx.eventBus().publish("testSubject", new JsonObject("{\"fail\": false, \"sleep\": 30, \"last\": true}"));
     allReceived.awaitSuccess();
 
-    waitForValue(vertx, context, "vertx.eventbus.processingTime[address=testSubject]$COUNT",
+    waitForValue(vertx, context, "vertx.eventbus.processed[address=testSubject,side=local]$COUNT",
       value -> value.intValue() == 8 * instances);
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(startsWith("vertx.eventbus"));
-    assertThat(datapoints).hasSize(12).contains(
+    assertThat(datapoints).hasSize(10).contains(
       dp("vertx.eventbus.handlers[address=testSubject]$VALUE", instances),
       dp("vertx.eventbus.pending[address=no handler,side=local]$VALUE", 0),
       dp("vertx.eventbus.pending[address=testSubject,side=local]$VALUE", 0),
@@ -101,14 +92,6 @@ public class VertxEventBusMetricsTest {
       dp("vertx.eventbus.received[address=testSubject,side=local]$COUNT", 8),
       dp("vertx.eventbus.delivered[address=testSubject,side=local]$COUNT", 8),
       dp("vertx.eventbus.replyFailures[address=no handler,failure=NO_HANDLERS]$COUNT", 2),
-      // dp("vertx.eventbus.errors[address=testSubject,class=RuntimeException]$COUNT", 2 * instances),
-      dp("vertx.eventbus.processingTime[address=testSubject]$COUNT", 8d * instances));
-
-    assertThat(datapoints)
-      .usingFieldByFieldElementComparator()
-      .usingComparatorForElementFieldsWithType(new DoubleComparator(1.0), Double.class)
-      .contains(
-        dp("vertx.eventbus.processingTime[address=testSubject]$TOTAL_TIME", 180d * instances / 1000d),
-        dp("vertx.eventbus.processingTime[address=testSubject]$MAX", 30d / 1000d));
+      dp("vertx.eventbus.processed[address=testSubject,side=local]$COUNT", 8d * instances));
   }
 }

--- a/src/test/java/io/vertx/micrometer/backend/PrometheusMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/PrometheusMetricsITest.java
@@ -142,7 +142,7 @@ public class PrometheusMetricsITest {
           "vertx_eventbus_received_total{address=\"test-eb\",side=\"local\",} 1.0",
           "vertx_eventbus_handlers{address=\"test-eb\",} 1.0",
           "vertx_eventbus_delivered_total{address=\"test-eb\",side=\"local\",} 1.0",
-          "vertx_eventbus_processingTime_seconds_count{address=\"test-eb\",} 1.0"));
+          "vertx_eventbus_processed_total{address=\"test-eb\",side=\"local\",} 1.0"));
       async.complete();
     });
     async.awaitSuccess(15000);


### PR DESCRIPTION
This is a follow-up on f369f39c20c120103a65701e9f689d197c97465d / https://github.com/eclipse-vertx/vert.x/issues/3270

A few notes:
- SPI was refactored by merging 'beginHandleMessage' and 'endHandleMessage' hooks, so measuring time became pointless
- processingTime was anyway not really relevant as it was missing any asynchronous-spent time
- Errors (=exceptions) are not provided anymore to metrics SPI
- Errors != replyFailures: the latter is still reported

Documentation also updated to reflect these changes
