### PR TITLE
[4.0] Reset pending gauge on handler unregistered

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -50,29 +50,11 @@ Sets metrics types that are disabled.
 |[[enabled]]`@enabled`|`Boolean`|+++
 Set whether metrics will be enabled on the Vert.x instance. Metrics are not enabled by default.
 +++
-|[[influxDbOptions]]`@influxDbOptions`|`link:dataobjects.html#VertxInfluxDbOptions[VertxInfluxDbOptions]`|+++
-Set InfluxDB options.
- Setting a registry backend option is mandatory in order to effectively report metrics.
-+++
-|[[jmxMetricsOptions]]`@jmxMetricsOptions`|`link:dataobjects.html#VertxJmxMetricsOptions[VertxJmxMetricsOptions]`|+++
-Set JMX metrics options.
- Setting a registry backend option is mandatory in order to effectively report metrics.
-+++
 |[[jvmMetricsEnabled]]`@jvmMetricsEnabled`|`Boolean`|+++
 Whether JVM metrics should be collected. Defaults to <code>false</code>.
 +++
-|[[labelMatches]]`@labelMatches`|`Array of link:dataobjects.html#Match[Match]`|+++
-Set a list of rules for label matching.
-+++
-|[[labelMatchs]]`@labelMatchs`|`Array of link:dataobjects.html#Match[Match]`|+++
-Add a rule for label matching.
-+++
 |[[labels]]`@labels`|`Array of link:enums.html#Label[Label]`|+++
 Sets enabled labels. These labels can be fine-tuned later on using Micrometer's Meter filters (see http://micrometer.io/docs/concepts#_meter_filters)
-+++
-|[[prometheusOptions]]`@prometheusOptions`|`link:dataobjects.html#VertxPrometheusOptions[VertxPrometheusOptions]`|+++
-Set Prometheus options.
- Setting a registry backend option is mandatory in order to effectively report metrics.
 +++
 |[[registryName]]`@registryName`|`String`|+++
 Set a name for the metrics registry, so that a new registry will be created and associated with this name.
@@ -169,9 +151,6 @@ Push interval steps, in seconds. Default is 10 seconds.
 ^|Name | Type ^| Description
 |[[embeddedServerEndpoint]]`@embeddedServerEndpoint`|`String`|+++
 Set metrics endpoint. Use conjointly with the embedded server options. Defaults to <i>/metrics</i>.
-+++
-|[[embeddedServerOptions]]`@embeddedServerOptions`|`link:dataobjects.html#HttpServerOptions[HttpServerOptions]`|+++
-HTTP server options for the embedded server
 +++
 |[[enabled]]`@enabled`|`Boolean`|+++
 Set true to enable Prometheus reporting

--- a/src/main/java/io/vertx/micrometer/impl/VertxEventBusMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxEventBusMetrics.java
@@ -75,6 +75,9 @@ class VertxEventBusMetrics extends AbstractMetrics implements EventBusMetrics<Ve
   public void handlerUnregistered(Handler handler) {
     if (isValid(handler)) {
       handlers.get(handler.address).decrement();
+      // Mirroring behaviour in vertx-core: any pending message gets discarded
+      pending.get(handler.address, Labels.getSide(true)).reset();
+      pending.get(handler.address, Labels.getSide(false)).reset();
     }
   }
 

--- a/src/test/java/io/vertx/micrometer/RegistryInspector.java
+++ b/src/test/java/io/vertx/micrometer/RegistryInspector.java
@@ -37,8 +37,12 @@ public final class RegistryInspector {
   private RegistryInspector() {
   }
 
-  public static void dump(String regName) {
-    listDatapoints(regName, a -> true).forEach(System.out::println);
+  public static void dump(Predicate<Meter> predicate) {
+    dump(MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME, predicate);
+  }
+
+  public static void dump(String regName, Predicate<Meter> predicate) {
+    listDatapoints(regName, predicate).forEach(System.out::println);
   }
 
   public static Predicate<Meter> startsWith(String start) {

--- a/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
@@ -1,15 +1,23 @@
 package io.vertx.micrometer;
 
-import io.vertx.core.*;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.assertj.core.util.DoubleComparator;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.vertx.micrometer.RegistryInspector.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,5 +101,62 @@ public class VertxEventBusMetricsTest {
       dp("vertx.eventbus.delivered[address=testSubject,side=local]$COUNT", 8),
       dp("vertx.eventbus.replyFailures[address=no handler,failure=NO_HANDLERS]$COUNT", 2),
       dp("vertx.eventbus.processed[address=testSubject,side=local]$COUNT", 8d * instances));
+  }
+
+  @Test
+  public void shouldFlushPendingOnUnregister(TestContext context) {
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+      .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+      .setEnabled(true)))
+      .exceptionHandler(t -> {
+        if (t.getMessage() == null || !t.getMessage().contains("expected failure")) {
+          context.exceptionHandler().handle(t);
+        }
+      });
+
+    Async step1EBReady = context.async();
+    Async step2FirstReceived = context.async();
+    Async step3BlockWorker = context.async();
+    AtomicBoolean first = new AtomicBoolean(true);
+    AtomicReference<MessageConsumer<Object>> consumerRef = new AtomicReference<>();
+
+    // Setup eventbus handler
+    vertx.deployVerticle(() -> new AbstractVerticle() {
+      @Override
+      public void start(Promise<Void> future) {
+        MessageConsumer<Object> consumer = vertx.eventBus().consumer("testSubject", msg -> {
+          if (first.getAndSet(false)) {
+            step2FirstReceived.complete();
+          }
+          step3BlockWorker.await();
+        });
+        consumerRef.set(consumer);
+        step1EBReady.complete();
+      }
+    }, new DeploymentOptions().setWorker(true));
+    step1EBReady.awaitSuccess();
+
+    // Send to eventbus
+    vertx.eventBus().publish("testSubject", new JsonObject());
+    vertx.eventBus().publish("testSubject", new JsonObject());
+    vertx.eventBus().publish("testSubject", new JsonObject());
+    vertx.eventBus().publish("testSubject", new JsonObject());
+
+    // Check pending count, as first event should block the other ones => expect 3 pending
+    step2FirstReceived.awaitSuccess();
+    // RegistryInspector.dump(startsWith("vertx.eventbus"));
+    waitForValue(vertx, context, "vertx.eventbus.published[side=local]$COUNT", value -> value.intValue() == 4);
+    List<RegistryInspector.Datapoint> datapoints = listDatapoints(startsWith("vertx.eventbus"));
+    assertThat(datapoints).contains(dp("vertx.eventbus.pending[side=local]$VALUE", 3));
+
+    // Unregister handler, then check pending again => should be 0
+    consumerRef.get().unregister();
+    // RegistryInspector.dump(startsWith("vertx.eventbus"));
+    waitForValue(vertx, context, "vertx.eventbus.handlers[]$VALUE", value -> value.intValue() == 0);
+    datapoints = listDatapoints(startsWith("vertx.eventbus"));
+    assertThat(datapoints).contains(dp("vertx.eventbus.pending[side=local]$VALUE", 0));
+
+    // (Unblock thread)
+    step3BlockWorker.complete();
   }
 }


### PR DESCRIPTION
This reports https://github.com/vert-x3/vertx-micrometer-metrics/pull/98 on master / 4.0

@tsegismont some weird thing here: the test written for 3.8 that you reviewed isn't valid here anymore. Something changed in EB behaviour that I don't know if it's intentional or a bug.

You can see in my test, I've added some logs. Here's the output:

```
Await EB ready...
EB ready!
Await first received...
First received!
Await thread unblock...
Await thread unblock...
Await thread unblock...
Await thread unblock...
vertx.eventbus.handlers[]$VALUE/1.0
vertx.eventbus.processed[side=local]$COUNT/4.0
vertx.eventbus.delivered[side=local]$COUNT/4.0
vertx.eventbus.received[side=local]$COUNT/4.0
vertx.eventbus.published[side=local]$COUNT/4.0
vertx.eventbus.pending[side=local]$VALUE/0.0

java.lang.AssertionError: 
Expecting:
 <[vertx.eventbus.handlers[]$VALUE/1.0,
    vertx.eventbus.processed[side=local]$COUNT/4.0,
    vertx.eventbus.delivered[side=local]$COUNT/4.0,
    vertx.eventbus.received[side=local]$COUNT/4.0,
    vertx.eventbus.published[side=local]$COUNT/4.0,
    vertx.eventbus.pending[side=local]$VALUE/0.0]>
to contain:
 <[vertx.eventbus.pending[side=local]$VALUE/3.0]>
but could not find:
 <[vertx.eventbus.pending[side=local]$VALUE/3.0]>
```

Notice the four `Await thread unblock...`: it means blocking a EB consumer thread doesn't block execution of next consumer calls anymore. So all events are consumed even if they're blocked.
Is this a bug or not?

The test would succeed without using a Worker verticle, this is specific to workers. So a quick fix could be to remove use of worker verticle, with a risk to block the event loop.