### PR TITLE
Implement ClientMetrics interface

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -44,7 +44,7 @@ Set the matched value.
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[disabledMetricsCategories]]`@disabledMetricsCategories`|`Array of link:enums.html#MetricsDomain[MetricsDomain]`|+++
+|[[disabledMetricsCategories]]`@disabledMetricsCategories`|`Array of String`|+++
 Sets metrics types that are disabled.
 +++
 |[[enabled]]`@enabled`|`Boolean`|+++

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -46,6 +46,9 @@ Pool type, such as "worker" or "datasource" (used in pools domain)
 |[[POOL_NAME]]`POOL_NAME`|+++
 Pool name (used in pools domain)
 +++
+|[[NAMESPACE]]`NAMESPACE`|+++
+Client namespace
++++
 |===
 
 [[MatchType]]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -725,3 +725,46 @@ NOTE: Vert.x creates two worker pools upfront, _worker-thread_ and _internal-blo
 |Number of verticle instances deployed.
 
 |===
+
+=== Other clients
+
+Vert.x clients, other than the core HTTP / Net clients, may implement a standard set of client metrics. This is the case, for instance, of the SQL client.
+
+Such client metrics are named after a "client type" identifier, displayed as `$TYPE` in the table below.
+For instance, `vertx_$TYPE_queue_size` is `vertx_sql_queue_size` for the SQL client.
+
+The meaning of the `namespace` label is left to the discretion of the client implementation.
+
+[cols="35,20,10,35", options="header"]
+|===
+|Metric name
+|Labels
+|Type
+|Description
+
+|`vertx_$TYPE_queue_pending`
+|`remote`, `namespace`
+|Gauge
+|Number of pending elements in queue.
+
+|`vertx_$TYPE_queue_time`
+|`remote`, `namespace`
+|Timer
+|Time spent in queue before being processed.
+
+|`vertx_$TYPE_processing_pending`
+|`remote`, `namespace`
+|Gauge
+|Number of elements being processed.
+
+|`vertx_$TYPE_processing_time`
+|`remote`, `namespace`
+|Timer
+|Processing time, from request start to response end.
+
+|`vertx_$TYPE_reset`
+|`remote`, `namespace`
+|Counter
+|Total number of requests reset.
+
+|===

--- a/src/main/generated/io/vertx/micrometer/MicrometerMetricsOptionsConverter.java
+++ b/src/main/generated/io/vertx/micrometer/MicrometerMetricsOptionsConverter.java
@@ -17,10 +17,10 @@ public class MicrometerMetricsOptionsConverter {
       switch (member.getKey()) {
         case "disabledMetricsCategories":
           if (member.getValue() instanceof JsonArray) {
-            java.util.LinkedHashSet<io.vertx.micrometer.MetricsDomain> list =  new java.util.LinkedHashSet<>();
+            java.util.LinkedHashSet<java.lang.String> list =  new java.util.LinkedHashSet<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.micrometer.MetricsDomain.valueOf((String)item));
+                list.add((String)item);
             });
             obj.setDisabledMetricsCategories(list);
           }
@@ -94,7 +94,7 @@ public class MicrometerMetricsOptionsConverter {
   public static void toJson(MicrometerMetricsOptions obj, java.util.Map<String, Object> json) {
     if (obj.getDisabledMetricsCategories() != null) {
       JsonArray array = new JsonArray();
-      obj.getDisabledMetricsCategories().forEach(item -> array.add(item.name()));
+      obj.getDisabledMetricsCategories().forEach(item -> array.add(item));
       json.put("disabledMetricsCategories", array);
     }
     json.put("enabled", obj.isEnabled());

--- a/src/main/java/io/vertx/micrometer/Label.java
+++ b/src/main/java/io/vertx/micrometer/Label.java
@@ -68,7 +68,11 @@ public enum Label {
   /**
    * Pool name (used in pools domain)
    */
-  POOL_NAME("pool_name");
+  POOL_NAME("pool_name"),
+  /**
+   * Client namespace
+   */
+  NAMESPACE("client_namespace");
 
   private String labelOutput;
 

--- a/src/main/java/io/vertx/micrometer/MetricsDomain.java
+++ b/src/main/java/io/vertx/micrometer/MetricsDomain.java
@@ -66,4 +66,9 @@ public enum MetricsDomain {
   public String getPrefix() {
     return prefix;
   }
+
+  public String toCategory() {
+    // E.g. "vertx.net.server." => "net.server"
+    return prefix.substring(6, prefix.length() - 1);
+  }
 }

--- a/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
+++ b/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
@@ -51,7 +51,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
    */
   public static final boolean DEFAULT_JVM_METRICS_ENABLED = false;
 
-  private Set<MetricsDomain> disabledMetricsCategories;
+  private Set<String> disabledMetricsCategories;
   private String registryName;
   private Set<Label> labels;
   private List<Match> labelMatches;
@@ -65,7 +65,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
    * Creates default options for Micrometer metrics.
    */
   public MicrometerMetricsOptions() {
-    disabledMetricsCategories = EnumSet.noneOf(MetricsDomain.class);
+    disabledMetricsCategories = new HashSet<>();
     registryName = DEFAULT_REGISTRY_NAME;
     labels = EnumSet.copyOf(DEFAULT_LABELS);
     labelMatches = new ArrayList<>();
@@ -77,7 +77,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
    */
   public MicrometerMetricsOptions(MicrometerMetricsOptions other) {
     super(other);
-    disabledMetricsCategories = other.disabledMetricsCategories != null ? EnumSet.copyOf(other.disabledMetricsCategories) : EnumSet.noneOf(MetricsDomain.class);
+    disabledMetricsCategories = other.disabledMetricsCategories != null ? new HashSet<>(other.disabledMetricsCategories) : new HashSet<>();
     registryName = other.registryName;
     labels = other.labels != null ? EnumSet.copyOf(other.labels) : EnumSet.noneOf(Label.class);
     labelMatches = new ArrayList<>(other.labelMatches);
@@ -142,7 +142,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
   /**
    * @return the disabled metrics types.
    */
-  public Set<MetricsDomain> getDisabledMetricsCategories() {
+  public Set<String> getDisabledMetricsCategories() {
     return disabledMetricsCategories;
   }
 
@@ -152,7 +152,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
    * @param disabledMetricsCategories to specify the set of metrics types to be disabled.
    * @return a reference to this, so that the API can be used fluently
    */
-  public MicrometerMetricsOptions setDisabledMetricsCategories(Set<MetricsDomain> disabledMetricsCategories) {
+  public MicrometerMetricsOptions setDisabledMetricsCategories(Set<String> disabledMetricsCategories) {
     this.disabledMetricsCategories = disabledMetricsCategories;
     return this;
   }
@@ -167,9 +167,25 @@ public class MicrometerMetricsOptions extends MetricsOptions {
   @GenIgnore
   public MicrometerMetricsOptions addDisabledMetricsCategory(MetricsDomain metricsDomain) {
     if (disabledMetricsCategories == null) {
-      disabledMetricsCategories = EnumSet.noneOf(MetricsDomain.class);
+      disabledMetricsCategories = new HashSet<>();
     }
-    this.disabledMetricsCategories.add(metricsDomain);
+    this.disabledMetricsCategories.add(metricsDomain.toCategory());
+    return this;
+  }
+
+  /**
+   * Set metric that will not be registered. Schedulers will check the set {@code disabledMetricsCategories} when
+   * registering metrics suppliers
+   *
+   * @param category the type of metrics
+   * @return a reference to this, so that the API can be used fluently
+   */
+  @GenIgnore
+  public MicrometerMetricsOptions addDisabledMetricsCategory(String category) {
+    if (disabledMetricsCategories == null) {
+      disabledMetricsCategories = new HashSet<>();
+    }
+    this.disabledMetricsCategories.add(category);
     return this;
   }
 
@@ -179,7 +195,16 @@ public class MicrometerMetricsOptions extends MetricsOptions {
    */
   @GenIgnore
   public boolean isMetricsCategoryDisabled(MetricsDomain metricsDomain) {
-    return disabledMetricsCategories != null && disabledMetricsCategories.contains(metricsDomain);
+    return disabledMetricsCategories != null && disabledMetricsCategories.contains(metricsDomain.toCategory());
+  }
+
+  /**
+   * Is the given metrics category disabled?
+   * @return true if it is disabled
+   */
+  @GenIgnore
+  public boolean isMetricsCategoryDisabled(String category) {
+    return disabledMetricsCategories != null && disabledMetricsCategories.contains(category);
   }
 
   /**

--- a/src/main/java/io/vertx/micrometer/impl/AbstractMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/AbstractMetrics.java
@@ -34,11 +34,21 @@ import java.util.concurrent.atomic.LongAdder;
  */
 public abstract class AbstractMetrics implements MicrometerMetrics {
   protected final MeterRegistry registry;
-  protected final MetricsDomain domain;
+  protected final String category;
+
+  AbstractMetrics(MeterRegistry registry) {
+    this.registry = registry;
+    this.category = null;
+  }
+
+  AbstractMetrics(MeterRegistry registry, String category) {
+    this.registry = registry;
+    this.category = category;
+  }
 
   AbstractMetrics(MeterRegistry registry, MetricsDomain domain) {
     this.registry = registry;
-    this.domain = domain;
+    this.category = (domain == null) ? null : domain.toCategory();
   }
 
   /**
@@ -51,26 +61,26 @@ public abstract class AbstractMetrics implements MicrometerMetrics {
 
   @Override
   public String baseName() {
-    return domain == null ? null : domain.getPrefix();
+    return category == null ? null : "vertx." + category + ".";
   }
 
   Counters counters(String name, String description, Label... keys) {
-    return new Counters(domain.getPrefix() + name, description, registry, keys);
+    return new Counters(baseName() + name, description, registry, keys);
   }
 
   Gauges<LongAdder> longGauges(String name, String description, Label... keys) {
-    return new Gauges<>(domain.getPrefix() + name, description, LongAdder::new, LongAdder::doubleValue, registry, keys);
+    return new Gauges<>(baseName() + name, description, LongAdder::new, LongAdder::doubleValue, registry, keys);
   }
 
   Gauges<AtomicReference<Double>> doubleGauges(String name, String description, Label... keys) {
-    return new Gauges<>(domain.getPrefix() + name, description, () -> new AtomicReference<>(0d), AtomicReference::get, registry, keys);
+    return new Gauges<>(baseName() + name, description, () -> new AtomicReference<>(0d), AtomicReference::get, registry, keys);
   }
 
   Summaries summaries(String name, String description, Label... keys) {
-    return new Summaries(domain.getPrefix() + name, description, registry, keys);
+    return new Summaries(baseName() + name, description, registry, keys);
   }
 
   Timers timers(String name, String description, Label... keys) {
-    return new Timers(domain.getPrefix() + name, description, registry, keys);
+    return new Timers(baseName() + name, description, registry, keys);
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/VertxClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxClientMetrics.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.micrometer.impl;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.micrometer.Label;
+import io.vertx.micrometer.impl.meters.Counters;
+import io.vertx.micrometer.impl.meters.Gauges;
+import io.vertx.micrometer.impl.meters.Timers;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * @author Joel Takvorian
+ */
+class VertxClientMetrics extends AbstractMetrics {
+  private final Timers queueTime;
+  private final Timers processingTime;
+  private final Gauges<LongAdder> queuePending;
+  private final Gauges<LongAdder> processingPending;
+  private final Counters resetCount;
+
+  VertxClientMetrics(MeterRegistry registry, String type) {
+    super(registry, type);
+    queueTime = timers("queueTime", "Time in queue, before processing", Label.REMOTE, Label.NAMESPACE);
+    queuePending = longGauges("queuePending", "Number of messages not processed yet", Label.REMOTE, Label.NAMESPACE);
+    processingTime = timers("processingTime", "Full processing time, including network latency", Label.REMOTE, Label.NAMESPACE);
+    processingPending = longGauges("processingPending", "Number of messages being processed", Label.REMOTE, Label.NAMESPACE);
+    resetCount = counters("resetCount", "Number of requests reset", Label.REMOTE, Label.NAMESPACE);
+  }
+
+  ClientMetrics forInstance(SocketAddress remoteAddress, String namespace) {
+    return new Instance(remoteAddress, namespace);
+  }
+
+  class Instance implements ClientMetrics<Timers.EventTiming, Timers.EventTiming, Void, Void> {
+    private final String remote;
+    private final String namespace;
+
+    Instance(SocketAddress remoteAddress, String namespace) {
+      this.remote = remoteAddress == null ? "" : remoteAddress.toString();
+      this.namespace = namespace == null ? "" : namespace;
+    }
+
+    @Override
+    public Timers.EventTiming enqueueRequest() {
+      queuePending.get(remote, namespace).increment();
+      return queueTime.start();
+    }
+
+    @Override
+    public void dequeueRequest(Timers.EventTiming taskMetric) {
+      queuePending.get(remote, namespace).decrement();
+      taskMetric.end(remote, namespace);
+    }
+
+    @Override
+    public Timers.EventTiming requestBegin(String uri, Void request) {
+      // Ignore parameters at the moment; need to carefully figure out what can be labelled or not
+      processingPending.get(remote, namespace).increment();
+      return processingTime.start();
+    }
+
+    @Override
+    public void requestEnd(Timers.EventTiming requestMetric) {
+      // Ignoring request-alone metrics at the moment
+    }
+
+    @Override
+    public void responseBegin(Timers.EventTiming requestMetric, Void response) {
+      // Ignoring response-alone metrics at the moment
+    }
+
+    @Override
+    public void requestReset(Timers.EventTiming requestMetric) {
+      processingPending.get(remote, namespace).decrement();
+      requestMetric.end(remote, namespace);
+      resetCount.get(remote, namespace).increment();
+    }
+
+    @Override
+    public void responseEnd(Timers.EventTiming requestMetric, Void response) {
+      processingPending.get(remote, namespace).decrement();
+      requestMetric.end(remote, namespace);
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
@@ -98,7 +98,7 @@ class VertxNetClientMetrics extends AbstractMetrics {
 
     @Override
     public String baseName() {
-      return domain.getPrefix();
+      return VertxNetClientMetrics.this.baseName();
     }
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
@@ -98,7 +98,7 @@ class VertxNetServerMetrics extends AbstractMetrics {
 
     @Override
     public String baseName() {
-      return domain.getPrefix();
+      return VertxNetServerMetrics.this.baseName();
     }
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/VertxPoolMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxPoolMetrics.java
@@ -112,7 +112,7 @@ class VertxPoolMetrics extends AbstractMetrics {
 
     @Override
     public String baseName() {
-      return domain.getPrefix();
+      return VertxPoolMetrics.this.baseName();
     }
   }
 }

--- a/src/test/java/io/vertx/micrometer/RegistryInspector.java
+++ b/src/test/java/io/vertx/micrometer/RegistryInspector.java
@@ -34,6 +34,8 @@ import java.util.stream.StreamSupport;
  * @author Joel Takvorian
  */
 public final class RegistryInspector {
+  public static Predicate<Meter> ALL = a -> true;
+
   private RegistryInspector() {
   }
 

--- a/src/test/java/io/vertx/micrometer/VertxClientMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxClientMetricsTest.java
@@ -1,0 +1,155 @@
+package io.vertx.micrometer;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Stack;
+
+import static io.vertx.micrometer.RegistryInspector.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Joel Takvorian
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxClientMetricsTest {
+
+  private Vertx vertx;
+
+  @After
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void shouldReportQueueClientMetrics(TestContext context) {
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+      .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+      .setEnabled(true)
+      .addLabels(Label.REMOTE, Label.NAMESPACE)
+    )).exceptionHandler(context.exceptionHandler());
+
+    FakeClient client = new FakeClient(vertx, "somewhere", "my namespace");
+
+    List<Datapoint> datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).isEmpty();
+
+    client.enqueue(10);
+    datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).containsOnly(
+      dp("vertx.fake.queue.pending[client_namespace=my namespace,remote=somewhere]$VALUE", 10));
+
+    client.dequeue(8);
+    datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).contains(
+      dp("vertx.fake.queue.pending[client_namespace=my namespace,remote=somewhere]$VALUE", 2),
+      dp("vertx.fake.queue.time[client_namespace=my namespace,remote=somewhere]$COUNT", 8));
+  }
+
+  @Test
+  public void shouldReportProcessedClientMetrics(TestContext context) {
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+      .setEnabled(true)
+      .addLabels(Label.REMOTE, Label.NAMESPACE)
+    )).exceptionHandler(context.exceptionHandler());
+
+    FakeClient client = new FakeClient(vertx, "somewhere", "my namespace");
+
+    List<Datapoint> datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).isEmpty();
+
+    client.process(6);
+    datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).containsOnly(
+      dp("vertx.fake.processing.pending[client_namespace=my namespace,remote=somewhere]$VALUE", 6));
+
+    client.processed(2);
+    datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).contains(
+      dp("vertx.fake.processing.pending[client_namespace=my namespace,remote=somewhere]$VALUE", 4),
+      dp("vertx.fake.processing.time[client_namespace=my namespace,remote=somewhere]$COUNT", 2));
+
+    client.reset(2);
+    datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).contains(
+      dp("vertx.fake.processing.pending[client_namespace=my namespace,remote=somewhere]$VALUE", 2),
+      dp("vertx.fake.processing.time[client_namespace=my namespace,remote=somewhere]$COUNT", 4),
+      dp("vertx.fake.reset[client_namespace=my namespace,remote=somewhere]$COUNT", 2));
+  }
+
+  @Test
+  public void shouldNotReportDisabledClientMetrics(TestContext context) {
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+      .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+      .setEnabled(true)
+      .addDisabledMetricsCategory("fake")
+      .addLabels(Label.REMOTE, Label.NAMESPACE)
+    )).exceptionHandler(context.exceptionHandler());
+
+    FakeClient client = new FakeClient(vertx, "somewhere", "my namespace");
+    client.enqueue(4);
+    client.dequeue(1);
+    List<Datapoint> datapoints = listDatapoints(RegistryInspector.ALL);
+    assertThat(datapoints).isEmpty();
+  }
+
+  static class FakeClient {
+    final Vertx vertx;
+    final ClientMetrics metrics;
+    final Stack<Object> queue = new Stack<>();
+    final Stack<Object> processing = new Stack<>();
+
+    FakeClient(Vertx vertx, String where, String namespace) {
+      this.vertx = vertx;
+      metrics = ((VertxInternal)vertx).metricsSPI().createClientMetrics(
+        SocketAddress.domainSocketAddress(where), "fake", namespace);
+    }
+
+    void enqueue(int quantity) {
+      for (int i = 0; i < quantity; i++) {
+        Object o = metrics.enqueueRequest();
+        queue.push(o);
+      }
+    }
+
+    void dequeue(int quantity) {
+      for (int i = 0; i < quantity; i++) {
+        Object o = queue.pop();
+        metrics.dequeueRequest(o);
+      }
+    }
+
+    void process(int quantity) {
+      for (int i = 0; i < quantity; i++) {
+        Object o = metrics.requestBegin("", "");
+        metrics.requestEnd(o);
+        processing.push(o);
+      }
+    }
+
+    void processed(int quantity) {
+      for (int i = 0; i < quantity; i++) {
+        Object o = processing.pop();
+        metrics.responseBegin(o, null);
+        metrics.responseEnd(o, null);
+      }
+    }
+
+    void reset(int quantity) {
+      for (int i = 0; i < quantity; i++) {
+        Object o = processing.pop();
+        metrics.requestReset(o);
+      }
+    }
+  }
+}

--- a/src/test/java/io/vertx/micrometer/VertxDatagramSocketMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxDatagramSocketMetricsTest.java
@@ -6,7 +6,6 @@ import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +13,6 @@ import org.junit.runner.RunWith;
 import java.util.List;
 
 import static io.vertx.micrometer.RegistryInspector.*;
-import static io.vertx.micrometer.RegistryInspector.dp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**


### PR DESCRIPTION
Creates 5 new metrics per type of client:
- vertx.xxx.queue.time (histogram)
- vertx.xxx.queue.pending (gauge)
- vertx.xxx.processing.time (histogram)
- vertx.xxx.processing.pending (gauge)
- vertx.xxx.reset (counter)

They're all labeled by remote address and namespace. The provided "type" (e.g. "sql") is used as metric prefix (e.g. "vertx.sql.").

There's some refactoring on categories / MetricDomains, as this was before a closed list (enum), now it's an opened list that accepts custom values (e.g. "sql"). Hence it's still possible to turn off just one "ClientMetrics" instance based on its type, via the metrics options.

Fixes https://github.com/vert-x3/vertx-micrometer-metrics/issues/106