### PR TITLE
Fix net client/server metrics

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -409,12 +409,12 @@ depending on the backend used.
 
 |`vertx_net_client_bytesReceived`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes received from the remote host.
 
 |`vertx_net_client_bytesSent`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes sent to the remote host.
 
 |`vertx_net_client_errors`
@@ -506,12 +506,12 @@ depending on the backend used.
 
 |`vertx_net_server_bytesReceived`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes received by the Net Server.
 
 |`vertx_net_server_bytesSent`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes sent by the Net Server.
 
 |`vertx_net_server_errors`

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -440,12 +440,12 @@ depending on the backend used.
 
 |`vertx_http_client_bytesReceived`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes received from the remote host.
 
 |`vertx_http_client_bytesSent`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes sent to the remote host.
 
 |`vertx_http_client_errors`
@@ -473,6 +473,11 @@ depending on the backend used.
 |Counter
 |Number of requests sent.
 
+|`vertx_http_client_request_bytes`
+|`local`, `remote`, `path`, `method`
+|Summary
+|Size in bytes of the requests.
+
 |`vertx_http_client_responseTime`
 |`local`, `remote`, `path`, `method`, `code`
 |Timer
@@ -482,6 +487,11 @@ depending on the backend used.
 |`local`, `remote`, `path`, `method`, `code`
 |Counter
 |Number of received responses.
+
+|`vertx_http_client_response_bytes`
+|`local`, `remote`, `path`, `method`, `code`
+|Summary
+|Size in bytes of the responses.
 
 |`vertx_http_client_wsConnections`
 |`local`, `remote`
@@ -537,12 +547,12 @@ depending on the backend used.
 
 |`vertx_http_server_bytesReceived`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes received by the HTTP Server.
 
 |`vertx_http_server_bytesSent`
 |`local`, `remote`
-|Summary
+|Counter
 |Number of bytes sent by the HTTP Server.
 
 |`vertx_http_server_errors`
@@ -565,10 +575,20 @@ depending on the backend used.
 |Counter
 |Number of requests reset.
 
+|`vertx_http_server_request_bytes`
+|`local`, `remote`, `path`, `method`
+|Summary
+|Size in bytes of the requests.
+
 |`vertx_http_server_responseTime`
 |`local`, `remote`, `path`, `method`, `code`, `route`
 |Timer
 |Request processing time.
+
+|`vertx_http_server_response_bytes`
+|`local`, `remote`, `path`, `method`, `code`, `route`
+|Summary
+|Size in bytes of the responses.
 
 |`vertx_http_client_wsConnections`
 |`local`, `remote`

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
@@ -17,20 +17,22 @@ package io.vertx.micrometer.impl;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.observability.HttpRequest;
+import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.impl.meters.Counters;
 import io.vertx.micrometer.impl.meters.Gauges;
+import io.vertx.micrometer.impl.meters.Summaries;
 import io.vertx.micrometer.impl.meters.Timers;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.IntSupplier;
 
 /**
  * @author Joel Takvorian
@@ -39,7 +41,9 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
   private final Gauges<LongAdder> requests;
   private final Counters requestCount;
   private final Counters requestResetCount;
+  private final Summaries requestBytes;
   private final Timers processingTime;
+  private final Summaries responseBytes;
   private final Gauges<LongAdder> wsConnections;
 
   VertxHttpServerMetrics(MeterRegistry registry) {
@@ -47,7 +51,9 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     requests = longGauges("requests", "Number of requests being processed", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     requestCount = counters("requestCount", "Number of processed requests", Label.LOCAL, Label.REMOTE, Label.HTTP_ROUTE, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE);
     requestResetCount = counters("requestResetCount", "Number of requests reset", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
+    requestBytes = summaries("request.bytes", "Size of requests in bytes", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     processingTime = timers("responseTime", "Request processing time", Label.LOCAL, Label.REMOTE, Label.HTTP_ROUTE, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE);
+    responseBytes = summaries("response.bytes", "Size of responses in bytes", Label.LOCAL, Label.REMOTE, Label.HTTP_ROUTE, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE);
     wsConnections = longGauges("wsConnections", "Number of websockets currently opened", Label.LOCAL, Label.REMOTE);
   }
 
@@ -62,8 +68,8 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     }
 
     @Override
-    public Handler requestBegin(String remote, HttpServerRequest request) {
-      Handler handler = new Handler(remote, request.path(), request.method().name());
+    public Handler requestBegin(String remote, HttpRequest request) {
+      Handler handler = new Handler(remote, request.uri(), request.method().name());
       requests.get(local, remote, handler.path, handler.method).increment();
       handler.timer = processingTime.start();
       return handler;
@@ -76,19 +82,31 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     }
 
     @Override
-    public Handler responsePushed(String remote, HttpMethod method, String uri, HttpServerResponse response) {
+    public void requestEnd(Handler handler, long bytesRead) {
+      requestBytes.get(local, handler.address, handler.path, handler.method).record(bytesRead);
+    }
+
+    @Override
+    public Handler responsePushed(String remote, HttpMethod method, String uri, HttpResponse response) {
       Handler handler = new Handler(remote, uri, method.name());
+      handler.code = response::statusCode;
       requests.get(local, remote, handler.path, handler.method).increment();
       return handler;
     }
 
     @Override
-    public void responseEnd(Handler handler, HttpServerResponse response) {
-      String code = String.valueOf(response.getStatusCode());
+    public void responseBegin(Handler handler, HttpResponse response) {
+      handler.code = response::statusCode;
+    }
+
+    @Override
+    public void responseEnd(Handler handler, long bytesWritten) {
+      String code = String.valueOf(handler.code.getAsInt());
       String handlerRoute = handler.getRoute();
       handler.timer.end(local, handler.address, handlerRoute, handler.path, handler.method, code);
       requestCount.get(local, handler.address, handlerRoute, handler.path, handler.method, code).increment();
       requests.get(local, handler.address, handler.path, handler.method).decrement();
+      responseBytes.get(local, handler.address, handlerRoute, handler.path, handler.method, code).record(bytesWritten);
     }
 
     @Override
@@ -118,6 +136,7 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
     private final String method;
     private final List<String> routes = new LinkedList<>();
     private Timers.EventTiming timer;
+    private IntSupplier code = () -> 0;
 
     Handler(String address, String path, String method) {
       this.address = address;

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
@@ -32,8 +32,8 @@ import java.util.concurrent.atomic.LongAdder;
  */
 class VertxNetClientMetrics extends AbstractMetrics {
   private final Gauges<LongAdder> connections;
-  private final Summaries bytesReceived;
-  private final Summaries bytesSent;
+  private final Counters bytesReceived;
+  private final Counters bytesSent;
   private final Counters errorCount;
 
   VertxNetClientMetrics(MeterRegistry registry) {
@@ -43,8 +43,8 @@ class VertxNetClientMetrics extends AbstractMetrics {
   VertxNetClientMetrics(MeterRegistry registry, MetricsDomain domain) {
     super(registry, domain);
     connections = longGauges("connections", "Number of connections to the remote host currently opened", Label.LOCAL, Label.REMOTE);
-    bytesReceived = summaries("bytesReceived", "Number of bytes received from the remote host", Label.LOCAL, Label.REMOTE);
-    bytesSent = summaries("bytesSent", "Number of bytes sent to the remote host", Label.LOCAL, Label.REMOTE);
+    bytesReceived = counters("bytesReceived", "Number of bytes received from the remote host", Label.LOCAL, Label.REMOTE);
+    bytesSent = counters("bytesSent", "Number of bytes sent to the remote host", Label.LOCAL, Label.REMOTE);
     errorCount = counters("errors", "Number of errors", Label.LOCAL, Label.REMOTE, Label.CLASS_NAME);
   }
 
@@ -73,12 +73,12 @@ class VertxNetClientMetrics extends AbstractMetrics {
 
     @Override
     public void bytesRead(String remote, SocketAddress remoteAddress, long numberOfBytes) {
-      bytesReceived.get(local, remote).record(numberOfBytes);
+      bytesReceived.get(local, remote).increment(numberOfBytes);
     }
 
     @Override
     public void bytesWritten(String remote, SocketAddress remoteAddress, long numberOfBytes) {
-      bytesSent.get(local, remote).record(numberOfBytes);
+      bytesSent.get(local, remote).increment(numberOfBytes);
     }
 
     @Override

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
@@ -31,8 +31,8 @@ import java.util.concurrent.atomic.LongAdder;
  */
 class VertxNetServerMetrics extends AbstractMetrics {
   private final Gauges<LongAdder> connections;
-  private final Summaries bytesReceived;
-  private final Summaries bytesSent;
+  private final Counters bytesReceived;
+  private final Counters bytesSent;
   private final Counters errorCount;
 
   VertxNetServerMetrics(MeterRegistry registry) {
@@ -42,8 +42,8 @@ class VertxNetServerMetrics extends AbstractMetrics {
   VertxNetServerMetrics(MeterRegistry registry, MetricsDomain domain) {
     super(registry, domain);
     connections = longGauges("connections", "Number of opened connections to the server", Label.LOCAL, Label.REMOTE);
-    bytesReceived = summaries("bytesReceived", "Number of bytes received by the server", Label.LOCAL, Label.REMOTE);
-    bytesSent = summaries("bytesSent", "Number of bytes sent by the server", Label.LOCAL, Label.REMOTE);
+    bytesReceived = counters("bytesReceived", "Number of bytes received by the server", Label.LOCAL, Label.REMOTE);
+    bytesSent = counters("bytesSent", "Number of bytes sent by the server", Label.LOCAL, Label.REMOTE);
     errorCount = counters("errors", "Number of errors", Label.LOCAL, Label.REMOTE, Label.CLASS_NAME);
   }
 
@@ -72,12 +72,12 @@ class VertxNetServerMetrics extends AbstractMetrics {
 
     @Override
     public void bytesRead(String remote, SocketAddress remoteAddress, long numberOfBytes) {
-      bytesReceived.get(local, remote).record(numberOfBytes);
+      bytesReceived.get(local, remote).increment(numberOfBytes);
     }
 
     @Override
     public void bytesWritten(String remote, SocketAddress remoteAddress, long numberOfBytes) {
-      bytesSent.get(local, remote).record(numberOfBytes);
+      bytesSent.get(local, remote).increment(numberOfBytes);
     }
 
     @Override

--- a/src/test/java/io/vertx/micrometer/UnixSocketTest.java
+++ b/src/test/java/io/vertx/micrometer/UnixSocketTest.java
@@ -45,8 +45,7 @@ public class UnixSocketTest {
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.net.client."));
     assertThat(datapoints).contains(
       dp("vertx.net.client.connections[remote=/var/tmp/myservice.sock]$VALUE", 0),
-      dp("vertx.net.client.bytesSent[remote=/var/tmp/myservice.sock]$COUNT", 1),
-      dp("vertx.net.client.bytesSent[remote=/var/tmp/myservice.sock]$TOTAL", 4));
+      dp("vertx.net.client.bytesSent[remote=/var/tmp/myservice.sock]$COUNT", 4));
   }
 
   public class DomainSocketServer extends AbstractVerticle {

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -92,16 +92,14 @@ public class VertxHttpClientServerMetricsTest {
     runClientRequests(ctx, false);
 
     waitForValue(vertx, ctx, registryName, "vertx.http.client.bytesReceived[local=?,remote=127.0.0.1:9195]$COUNT",
-      value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
+      value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length);
 
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.client."));
-    assertThat(datapoints).hasSize(15).contains(
+    assertThat(datapoints).hasSize(13).contains(
         dp("vertx.http.client.queue.size[local=?,remote=127.0.0.1:9195]$VALUE", 0),
         dp("vertx.http.client.queue.delay[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-        dp("vertx.http.client.bytesReceived[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-        dp("vertx.http.client.bytesReceived[local=?,remote=127.0.0.1:9195]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
-        dp("vertx.http.client.bytesSent[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-        dp("vertx.http.client.bytesSent[local=?,remote=127.0.0.1:9195]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+        dp("vertx.http.client.bytesReceived[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+        dp("vertx.http.client.bytesSent[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
         dp("vertx.http.client.requestCount[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
         dp("vertx.http.client.responseCount[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT));
 
@@ -118,7 +116,7 @@ public class VertxHttpClientServerMetricsTest {
     runClientRequests(ctx, false);
 
     waitForValue(vertx, ctx, registryName, "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
-      value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
+      value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length);
 
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).containsOnly(
@@ -126,18 +124,14 @@ public class VertxHttpClientServerMetricsTest {
       "vertx.http.server.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$VALUE",
       "vertx.http.server.connections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
-      "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$TOTAL",
       "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT",
-      "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$TOTAL",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$TOTAL_TIME",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$MAX");
 
     assertThat(datapoints).contains(
-      dp("vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-      dp("vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-      dp("vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-      dp("vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+      dp("vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+      dp("vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
       dp("vertx.http.server.requestCount[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT", concurrentClients * HTTP_SENT_COUNT));
   }
 
@@ -146,8 +140,8 @@ public class VertxHttpClientServerMetricsTest {
     runClientRequests(ctx, true);
 
     // Remark, with websockets, two extra requests are performed so increase the expected value
-    waitForValue(vertx, ctx, registryName, "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
-      value -> value.intValue() == concurrentClients * (SENT_COUNT + 2));
+    waitForValue(vertx, ctx, registryName, "vertx.http.server.requestCount[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
+      value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
 
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).containsOnly(
@@ -156,9 +150,7 @@ public class VertxHttpClientServerMetricsTest {
       "vertx.http.server.connections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.wsConnections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
-      "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$TOTAL",
       "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT",
-      "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$TOTAL",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$TOTAL_TIME",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$MAX",
@@ -168,19 +160,14 @@ public class VertxHttpClientServerMetricsTest {
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$TOTAL_TIME",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$COUNT",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$MAX");
-
-    assertThat(datapoints).contains(
-      dp("vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * (SENT_COUNT + 2)),
-      dp("vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * (SENT_COUNT + 1)),
-      dp("vertx.http.server.requestCount[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT", concurrentClients * HTTP_SENT_COUNT));
   }
 
   @Test
   public void shouldIgnoreInternalEventbusMetrics(TestContext ctx) {
     runClientRequests(ctx, true);
 
-    waitForValue(vertx, ctx, registryName, "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
-      value -> value.intValue() == concurrentClients * (SENT_COUNT + 2));
+    waitForValue(vertx, ctx, registryName, "vertx.http.server.requestCount[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
+      value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
 
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.eventbus."));
     assertThat(datapoints).isEmpty();

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class VertxHttpClientServerMetricsTest {
 
   private static final int HTTP_SENT_COUNT = 68;
-  private static final int SENT_COUNT = HTTP_SENT_COUNT + 1;
   private static final String SERVER_RESPONSE = "some text";
   private static final String CLIENT_REQUEST = "pitchounette";
   private static final long REQ_DELAY = 30L;
@@ -95,12 +94,16 @@ public class VertxHttpClientServerMetricsTest {
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length);
 
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.client."));
-    assertThat(datapoints).hasSize(13).contains(
+    assertThat(datapoints).hasSize(17).contains(
         dp("vertx.http.client.queue.size[local=?,remote=127.0.0.1:9195]$VALUE", 0),
         dp("vertx.http.client.queue.delay[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
         dp("vertx.http.client.bytesReceived[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
         dp("vertx.http.client.bytesSent[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+        dp("vertx.http.client.request.bytes[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+        dp("vertx.http.client.request.bytes[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
         dp("vertx.http.client.requestCount[local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+        dp("vertx.http.client.response.bytes[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+        dp("vertx.http.client.response.bytes[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
         dp("vertx.http.client.responseCount[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT));
 
     assertThat(datapoints).extracting(Datapoint::id).contains(
@@ -125,6 +128,10 @@ public class VertxHttpClientServerMetricsTest {
       "vertx.http.server.connections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
       "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$TOTAL",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$TOTAL_TIME",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$MAX");
@@ -132,6 +139,10 @@ public class VertxHttpClientServerMetricsTest {
     assertThat(datapoints).contains(
       dp("vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
       dp("vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+      dp("vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+      dp("vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
       dp("vertx.http.server.requestCount[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT", concurrentClients * HTTP_SENT_COUNT));
   }
 
@@ -151,15 +162,23 @@ public class VertxHttpClientServerMetricsTest {
       "vertx.http.server.wsConnections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.bytesReceived[local=127.0.0.1:9195,remote=_]$COUNT",
       "vertx.http.server.bytesSent[local=127.0.0.1:9195,remote=_]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$TOTAL",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$TOTAL_TIME",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$MAX",
       // Following ones result from the WS connection
       "vertx.http.server.requests[local=127.0.0.1:9195,method=GET,path=/,remote=_]$VALUE",
-      "vertx.http.server.requestCount[code=200,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$COUNT",
-      "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$TOTAL_TIME",
-      "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$COUNT",
-      "vertx.http.server.responseTime[code=200,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$MAX");
+      "vertx.http.server.requestCount[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=GET,path=/,remote=_]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=GET,path=/,remote=_]$TOTAL",
+      "vertx.http.server.response.bytes[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$COUNT",
+      "vertx.http.server.response.bytes[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$TOTAL",
+      "vertx.http.server.responseTime[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$TOTAL_TIME",
+      "vertx.http.server.responseTime[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$COUNT",
+      "vertx.http.server.responseTime[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,route=]$MAX");
   }
 
   @Test

--- a/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
@@ -82,35 +82,31 @@ public class VertxNetClientServerMetricsTest {
   }
 
   @Test
-  public void shouldReportNetClientMetrics(TestContext ctx) throws InterruptedException {
+  public void shouldReportNetClientMetrics(TestContext ctx) {
     runClientRequests(ctx);
 
     waitForValue(vertx, ctx, registryName, "vertx.net.client.bytesReceived[local=?,remote=localhost:9194]$COUNT",
-      value -> value.intValue() == concurrentClients * SENT_COUNT);
+      value -> value.intValue() == concurrentClients * SENT_COUNT * SERVER_RESPONSE.getBytes().length);
 
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.net.client."));
     assertThat(datapoints).containsOnly(
         dp("vertx.net.client.connections[local=?,remote=localhost:9194]$VALUE", 0),
-        dp("vertx.net.client.bytesReceived[local=?,remote=localhost:9194]$COUNT", concurrentClients * SENT_COUNT),
-        dp("vertx.net.client.bytesReceived[local=?,remote=localhost:9194]$TOTAL", concurrentClients * SENT_COUNT * SERVER_RESPONSE.getBytes().length),
-        dp("vertx.net.client.bytesSent[local=?,remote=localhost:9194]$COUNT", concurrentClients * SENT_COUNT),
-        dp("vertx.net.client.bytesSent[local=?,remote=localhost:9194]$TOTAL", concurrentClients * SENT_COUNT * CLIENT_REQUEST.getBytes().length));
+        dp("vertx.net.client.bytesReceived[local=?,remote=localhost:9194]$COUNT", concurrentClients * SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+        dp("vertx.net.client.bytesSent[local=?,remote=localhost:9194]$COUNT", concurrentClients * SENT_COUNT * CLIENT_REQUEST.getBytes().length));
   }
 
   @Test
-  public void shouldReportHttpServerMetrics(TestContext ctx) throws InterruptedException {
+  public void shouldReportNetServerMetrics(TestContext ctx) {
     runClientRequests(ctx);
 
     waitForValue(vertx, ctx, registryName, "vertx.net.server.bytesReceived[local=localhost:9194,remote=_]$COUNT",
-      value -> value.intValue() == concurrentClients * SENT_COUNT);
+      value -> value.intValue() == concurrentClients * SENT_COUNT * CLIENT_REQUEST.getBytes().length);
 
     List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.net.server."));
     assertThat(datapoints).containsOnly(
       dp("vertx.net.server.connections[local=localhost:9194,remote=_]$VALUE", 0),
-      dp("vertx.net.server.bytesReceived[local=localhost:9194,remote=_]$COUNT", concurrentClients * SENT_COUNT),
-      dp("vertx.net.server.bytesReceived[local=localhost:9194,remote=_]$TOTAL", concurrentClients * SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-      dp("vertx.net.server.bytesSent[local=localhost:9194,remote=_]$COUNT", concurrentClients * SENT_COUNT),
-      dp("vertx.net.server.bytesSent[local=localhost:9194,remote=_]$TOTAL", concurrentClients * SENT_COUNT * SERVER_RESPONSE.getBytes().length));
+      dp("vertx.net.server.bytesReceived[local=localhost:9194,remote=_]$COUNT", concurrentClients * SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+      dp("vertx.net.server.bytesSent[local=localhost:9194,remote=_]$COUNT", concurrentClients * SENT_COUNT * SERVER_RESPONSE.getBytes().length));
   }
 
   private void runClientRequests(TestContext ctx) {

--- a/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
+++ b/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
@@ -103,15 +103,9 @@ public class MetricsServiceImplTest {
 
     assertThat(snapshot).flatExtracting(e -> (List<JsonObject>) ((JsonArray) (e.getValue())).getList())
       .filteredOn(obj -> obj.getString("type").equals("counter"))
-      .hasSize(6)
+      .hasSize(10)
       .flatExtracting(JsonObject::fieldNames)
       .contains("count");
-
-    assertThat(snapshot).flatExtracting(e -> (List<JsonObject>) ((JsonArray) (e.getValue())).getList())
-      .filteredOn(obj -> obj.getString("type").equals("summary"))
-      .hasSize(4)
-      .flatExtracting(JsonObject::fieldNames)
-      .contains("mean", "max", "total");
 
     assertThat(snapshot).flatExtracting(e -> (List<JsonObject>) ((JsonArray) (e.getValue())).getList())
       .filteredOn(obj -> obj.getString("type").equals("timer"))

--- a/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
+++ b/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
@@ -90,15 +90,19 @@ public class MetricsServiceImplTest {
       "vertx.http.client.connections",
       "vertx.http.client.queue.delay",
       "vertx.http.client.queue.size",
+      "vertx.http.client.request.bytes",
       "vertx.http.client.requestCount",
       "vertx.http.client.requests",
+      "vertx.http.client.response.bytes",
       "vertx.http.client.responseCount",
       "vertx.http.client.responseTime",
       "vertx.http.server.bytesReceived",
       "vertx.http.server.bytesSent",
       "vertx.http.server.connections",
+      "vertx.http.server.request.bytes",
       "vertx.http.server.requestCount",
       "vertx.http.server.requests",
+      "vertx.http.server.response.bytes",
       "vertx.http.server.responseTime");
 
     assertThat(snapshot).flatExtracting(e -> (List<JsonObject>) ((JsonArray) (e.getValue())).getList())
@@ -125,8 +129,10 @@ public class MetricsServiceImplTest {
       "vertx.http.server.bytesReceived",
       "vertx.http.server.bytesSent",
       "vertx.http.server.connections",
+      "vertx.http.server.request.bytes",
       "vertx.http.server.requestCount",
       "vertx.http.server.requests",
+      "vertx.http.server.response.bytes",
       "vertx.http.server.responseTime");
   }
 


### PR DESCRIPTION
Having a summary for bytes read/write doesn't make sense anymore (see https://github.com/eclipse-vertx/vert.x/pull/3586)
Change them to counter.

As a follow-up we can create metrics for req/resp sizes, just for HTTP.

Related to https://github.com/eclipse-vertx/vert.x/issues/3585


@vietj this should fix the test failures