### PR TITLE
Fix broken test, missing "vertx.net.client.active.connections"

### DIFF
--- a/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
+++ b/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
@@ -105,7 +105,8 @@ public class MetricsServiceImplTest {
       "vertx.http.server.request.bytes",
       "vertx.http.server.requests",
       "vertx.http.server.response.bytes",
-      "vertx.http.server.response.time"
+      "vertx.http.server.response.time",
+      "vertx.net.client.active.connections"
     );
 
     assertThat(snapshot).flatExtracting(e -> (List<JsonObject>) ((JsonArray) (e.getValue())).getList())


### PR DESCRIPTION
When HTTP client requests are performed, now the metric "vertx.net.client.active.connections" is generated in addition to the expected "vertx.http.client.active.connections"

DNM until figured out what happens...

@vietj any idea what could trigger that change in the http client module ? To me it looks like a regression, I wouldn't expect metrics endpoint from the net client being invoked while using the http client.