### PR TITLE
Implement custom tags provider for HTTP metrics

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -369,6 +369,19 @@ Here is an example to replace the actual `path` label of HTTP requests with a ge
 
 NOTE: Matchers use MeterFilters under the hood.
 
+=== Custom tags provider
+
+You can define a function that generates additional tags (or labels) for HTTP server metrics.
+Such function takes an {@link io.vertx.core.spi.observability.HttpRequest} object as a parameter, and returns
+an Iterable of {@link io.micrometer.core.instrument.Tag}.
+
+As an example, here is how to map the _x-user_ header to a custom label _user_:
+
+[source,$lang]
+----
+{@link examples.MicrometerMetricsExamples#useCustomTagsProvider()}
+----
+
 === Snapshots
 
 A {@link io.vertx.micrometer.MetricsService} can be created out of a {@link io.vertx.core.metrics.Measured} object

--- a/src/main/java/examples/MicrometerMetricsExamples.java
+++ b/src/main/java/examples/MicrometerMetricsExamples.java
@@ -18,6 +18,7 @@ package examples;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
@@ -42,6 +43,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.micrometer.*;
 import io.vertx.micrometer.backends.BackendRegistries;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -272,6 +274,17 @@ public class MicrometerMetricsExamples {
       new MicrometerMetricsOptions()
         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
         .setMetricsNaming(MetricsNaming.v3Names())
+        .setEnabled(true)));
+  }
+
+  public void useCustomTagsProvider() {
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+      new MicrometerMetricsOptions()
+        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+        .setRequestsTagsProvider(req -> {
+          String user = req.headers().get("x-user");
+          return Collections.singletonList(Tag.of("user", user));
+        })
         .setEnabled(true)));
   }
 }

--- a/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
+++ b/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
@@ -16,14 +16,17 @@
 package io.vertx.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.VertxMetricsFactory;
+import io.vertx.core.spi.observability.HttpRequest;
 
 import java.util.*;
+import java.util.function.Function;
 
 /**
  * Vert.x micrometer configuration.
@@ -66,6 +69,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
   private VertxJmxMetricsOptions jmxMetricsOptions;
   private boolean jvmMetricsEnabled;
   private MetricsNaming metricsNaming;
+  private Function<HttpRequest, Iterable<Tag>> requestsTagsProvider;
 
   /**
    * Creates default options for Micrometer metrics.
@@ -77,6 +81,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
     labelMatches = new ArrayList<>();
     jvmMetricsEnabled = DEFAULT_JVM_METRICS_ENABLED;
     metricsNaming = DEFAULT_METRICS_NAMING;
+    requestsTagsProvider = null;
   }
 
   /**
@@ -100,6 +105,7 @@ public class MicrometerMetricsOptions extends MetricsOptions {
     }
     jvmMetricsEnabled = other.jvmMetricsEnabled;
     metricsNaming = other.metricsNaming;
+    requestsTagsProvider = other.requestsTagsProvider;
   }
 
   /**
@@ -413,6 +419,26 @@ public class MicrometerMetricsOptions extends MetricsOptions {
    */
   public MicrometerMetricsOptions setMetricsNaming(MetricsNaming metricsNaming) {
     this.metricsNaming = metricsNaming;
+    return this;
+  }
+
+  /**
+   * @return an optional custom tags provider for HTTP requests
+   */
+  @GenIgnore
+  public Function<HttpRequest, Iterable<Tag>> getRequestsTagsProvider() {
+    return requestsTagsProvider;
+  }
+
+  /**
+   * Sets a custom tags provider for HTTP requests. Allows to generate custom tags for every {@code HttpRequest} object processed through the metrics SPI.
+   *
+   * @param requestsTagsProvider an object implementing the {@code CustomTagsProvider} interface for {@code HttpRequest}.
+   * @return a reference to this, so that the API can be used fluently
+   */
+  @GenIgnore
+  public MicrometerMetricsOptions setRequestsTagsProvider(Function<HttpRequest, Iterable<Tag>> requestsTagsProvider) {
+    this.requestsTagsProvider = requestsTagsProvider;
     return this;
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
@@ -93,7 +93,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     httpClientMetrics = options.isMetricsCategoryDisabled(HTTP_CLIENT) ? null
       : new VertxHttpClientMetrics(registry, names);
     httpServerMetrics = options.isMetricsCategoryDisabled(HTTP_SERVER) ? null
-      : new VertxHttpServerMetrics(registry, names);
+      : new VertxHttpServerMetrics(registry, names, options.getRequestsTagsProvider());
     poolMetrics = options.isMetricsCategoryDisabled(NAMED_POOLS) ? null
       : new VertxPoolMetrics(registry, names);
   }

--- a/src/main/java/io/vertx/micrometer/impl/meters/Counters.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Counters.java
@@ -18,8 +18,14 @@ package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.impl.Labels;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Joel Takvorian
@@ -41,10 +47,17 @@ public class Counters {
   }
 
   public Counter get(String... values) {
+    return get(null, values);
+  }
+
+  public Counter get(Iterable<Tag> customTags, String... values) {
+    List<Tag> tags = customTags != null
+      ? Stream.concat(Labels.toTags(keys, values).stream(), StreamSupport.stream(customTags.spliterator(), false)).collect(Collectors.toList())
+      : Labels.toTags(keys, values);
     // Get or create the Counter
     return Counter.builder(name)
       .description(description)
-      .tags(Labels.toTags(keys, values))
+      .tags(tags)
       .register(registry);
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/meters/Summaries.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Summaries.java
@@ -18,8 +18,14 @@ package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.impl.Labels;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Joel Takvorian
@@ -41,10 +47,17 @@ public class Summaries {
   }
 
   public DistributionSummary get(String... values) {
+    return get(null, values);
+  }
+
+  public DistributionSummary get(Iterable<Tag> customTags, String... values) {
+    List<Tag> tags = customTags != null
+      ? Stream.concat(Labels.toTags(keys, values).stream(), StreamSupport.stream(customTags.spliterator(), false)).collect(Collectors.toList())
+      : Labels.toTags(keys, values);
     // Get or create the Summary
     return DistributionSummary.builder(name)
       .description(description)
-      .tags(Labels.toTags(keys, values))
+      .tags(tags)
       .register(registry);
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/meters/Timers.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Timers.java
@@ -17,11 +17,16 @@
 package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.impl.Labels;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Joel Takvorian
@@ -43,10 +48,17 @@ public class Timers {
   }
 
   public Timer get(String... values) {
+    return get(null, values);
+  }
+
+  public Timer get(Iterable<Tag> customTags, String... values) {
+    List<Tag> tags = customTags != null
+      ? Stream.concat(Labels.toTags(keys, values).stream(), StreamSupport.stream(customTags.spliterator(), false)).collect(Collectors.toList())
+      : Labels.toTags(keys, values);
     // Get or create the Timer
     return Timer.builder(name)
       .description(description)
-      .tags(Labels.toTags(keys, values))
+      .tags(tags)
       .register(registry);
   }
 
@@ -64,7 +76,11 @@ public class Timers {
     }
 
     public void end(String... values) {
-      Timer t = ref.get(values);
+      end(null, values);
+    }
+
+    public void end(Iterable<Tag> customTags, String... values) {
+      Timer t = ref.get(customTags, values);
       t.record(System.nanoTime() - nanoStart, TimeUnit.NANOSECONDS);
     }
   }

--- a/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
@@ -1,0 +1,115 @@
+package io.vertx.micrometer;
+
+import io.micrometer.core.instrument.Tag;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static io.vertx.micrometer.RegistryInspector.Datapoint;
+import static io.vertx.micrometer.RegistryInspector.listDatapoints;
+import static io.vertx.micrometer.RegistryInspector.startsWith;
+import static io.vertx.micrometer.RegistryInspector.waitForValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Joel Takvorian
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxHttpServerMetricsConfigTest {
+  private final String registryName = UUID.randomUUID().toString();
+  private HttpServer httpServer;
+  private Vertx vertx;
+
+  @After
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void shouldReportHttpServerMetricsWithCustomTags(TestContext ctx) {
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
+      .setRequestsTagsProvider(req -> {
+        String user = req.headers().get("user");
+        return Collections.singletonList(Tag.of("user", user));
+      })
+      .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+      .setRegistryName(registryName)
+      .setEnabled(true)))
+      .exceptionHandler(ctx.exceptionHandler());
+
+    prepareServer(ctx);
+    HttpClient client = vertx.createHttpClient();
+    sendRequest(ctx, client, "alice");
+    sendRequest(ctx, client, "bob");
+
+    waitForValue(vertx, ctx, registryName, "vertx.http.client.response.time[code=200,method=POST]$COUNT",
+      value -> value.intValue() == 2);
+    waitForValue(vertx, ctx, registryName, "vertx.http.client.active.requests[method=POST]$VALUE",
+      value -> value.intValue() == 0);
+
+    List<Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.server."));
+    assertThat(datapoints).extracting(Datapoint::id).contains(
+      "vertx.http.server.requests[code=200,method=POST,route=,user=alice]$COUNT",
+      "vertx.http.server.active.requests[method=POST,user=alice]$VALUE",
+      "vertx.http.server.response.time[code=200,method=POST,route=,user=alice]$COUNT",
+      "vertx.http.server.requests[code=200,method=POST,route=,user=bob]$COUNT",
+      "vertx.http.server.active.requests[method=POST,user=bob]$VALUE",
+      "vertx.http.server.response.time[code=200,method=POST,route=,user=bob]$COUNT");
+  }
+
+  private void prepareServer(TestContext ctx) {
+    // Setup server
+    Async serverReady = ctx.async();
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start(Promise<Void> future) throws Exception {
+        httpServer = vertx.createHttpServer();
+        httpServer
+          .requestHandler(req -> {
+            vertx.setTimer(30L, handler ->
+              req.response().setChunked(true).putHeader("Content-Type", "text/plain").end(""));
+          })
+          .listen(9195, "127.0.0.1", r -> {
+            if (r.failed()) {
+              ctx.fail(r.cause());
+            } else {
+              serverReady.complete();
+            }
+          });
+      }
+    });
+    serverReady.awaitSuccess();
+  }
+
+  private void sendRequest(TestContext ctx, HttpClient client, String user) {
+    Async async = ctx.async();
+    client.request(HttpMethod.POST, 9195, "127.0.0.1", "/")
+      .compose(req -> req
+        .putHeader("user", user)
+        .send("")
+        .compose(response -> {
+          if (response.statusCode() != 200) {
+            return Future.failedFuture(response.statusMessage());
+          } else {
+            return response.body();
+          }
+        }))
+      .onComplete(ctx.asyncAssertSuccess(v -> async.countDown()));
+    async.await();
+  }
+}

--- a/src/test/java/io/vertx/micrometer/impl/meters/CountersTest.java
+++ b/src/test/java/io/vertx/micrometer/impl/meters/CountersTest.java
@@ -2,6 +2,7 @@ package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.Match;
@@ -9,8 +10,10 @@ import io.vertx.micrometer.MatchType;
 import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,5 +64,16 @@ public class CountersTest {
     assertThat(c).isNull();
     c = registry.find("my_counter").tags("address", "addr2").counter();
     assertThat(c).isNull();
+  }
+
+  @Test
+  public void shouldAddCustomTags() {
+    List<Tag> customTags = Arrays.asList(Tag.of("k1", "v1"), Tag.of("k2", "v2"));
+    MeterRegistry registry = new SimpleMeterRegistry();
+    Counters counters = new Counters("my_counter", "", registry, Label.EB_ADDRESS);
+    counters.get(customTags, "addr1").increment();
+
+    Counter c = registry.find("my_counter").tags("address", "addr1", "k1", "v1", "k2", "v2").counter();
+    assertThat(c.count()).isEqualTo(1d);
   }
 }

--- a/src/test/java/io/vertx/micrometer/impl/meters/GaugesTest.java
+++ b/src/test/java/io/vertx/micrometer/impl/meters/GaugesTest.java
@@ -2,6 +2,7 @@ package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.Match;
@@ -9,8 +10,10 @@ import io.vertx.micrometer.MatchType;
 import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,5 +65,16 @@ public class GaugesTest {
     assertThat(g).isNull();
     g = registry.find("my_gauge").tags("address", "addr2").gauge();
     assertThat(g).isNull();
+  }
+
+  @Test
+  public void shouldAddCustomTags() {
+    List<Tag> customTags = Arrays.asList(Tag.of("k1", "v1"), Tag.of("k2", "v2"));
+    MeterRegistry registry = new SimpleMeterRegistry();
+    Gauges<LongAdder> gauges = new Gauges<>("my_gauge", "", LongAdder::new, LongAdder::doubleValue, registry, Label.EB_ADDRESS);
+    gauges.get(customTags, "addr1").increment();
+
+    Gauge g = registry.find("my_gauge").tags("address", "addr1", "k1", "v1", "k2", "v2").gauge();
+    assertThat(g.value()).isEqualTo(1d);
   }
 }

--- a/src/test/java/io/vertx/micrometer/impl/meters/SummariesTest.java
+++ b/src/test/java/io/vertx/micrometer/impl/meters/SummariesTest.java
@@ -2,6 +2,7 @@ package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.Match;
@@ -9,8 +10,10 @@ import io.vertx.micrometer.MatchType;
 import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,5 +67,16 @@ public class SummariesTest {
     assertThat(s).isNull();
     s = registry.find("my_summary").tags("address", "addr2").summary();
     assertThat(s).isNull();
+  }
+
+  @Test
+  public void shouldAddCustomTags() {
+    List<Tag> customTags = Arrays.asList(Tag.of("k1", "v1"), Tag.of("k2", "v2"));
+    MeterRegistry registry = new SimpleMeterRegistry();
+    Summaries summaries = new Summaries("my_summary", "", registry, Label.EB_ADDRESS);
+    summaries.get(customTags, "addr1").record(5);
+
+    DistributionSummary s = registry.find("my_summary").tags("address", "addr1", "k1", "v1", "k2", "v2").summary();
+    assertThat(s.count()).isEqualTo(1);
   }
 }

--- a/src/test/java/io/vertx/micrometer/impl/meters/TimersTest.java
+++ b/src/test/java/io/vertx/micrometer/impl/meters/TimersTest.java
@@ -1,6 +1,7 @@
 package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.micrometer.Label;
@@ -9,8 +10,10 @@ import io.vertx.micrometer.MatchType;
 import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,5 +68,16 @@ public class TimersTest {
     assertThat(t).isNull();
     t = registry.find("my_timer").tags("address", "addr2").timer();
     assertThat(t).isNull();
+  }
+
+  @Test
+  public void shouldAddCustomTags() {
+    List<Tag> customTags = Arrays.asList(Tag.of("k1", "v1"), Tag.of("k2", "v2"));
+    MeterRegistry registry = new SimpleMeterRegistry();
+    Timers timers = new Timers("my_timer", "", registry, Label.EB_ADDRESS);
+    timers.get(customTags, "addr1").record(5, TimeUnit.MILLISECONDS);
+
+    Timer t = registry.find("my_timer").tags("address", "addr1", "k1", "v1", "k2", "v2").timer();
+    assertThat(t).isNotNull();
   }
 }

--- a/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
+++ b/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
@@ -105,7 +105,8 @@ public class MetricsServiceImplTest {
       "vertx.http.server.request.bytes",
       "vertx.http.server.requests",
       "vertx.http.server.response.bytes",
-      "vertx.http.server.response.time"
+      "vertx.http.server.response.time",
+      "vertx.net.client.active.connections"
     );
 
     assertThat(snapshot).flatExtracting(e -> (List<JsonObject>) ((JsonArray) (e.getValue())).getList())


### PR DESCRIPTION
- Allows to implement a CustomTagsProvider interface to provide tags out
of HttpRequest objects.
- Add tests

Fixes https://github.com/vert-x3/vertx-micrometer-metrics/issues/89
