### PR TITLE
Bump micrometer from 1.6.2  to 1.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <assertj.version>3.9.0</assertj.version>
     <junit.version>4.13.1</junit.version>
     <maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
-    <micrometer.version>1.6.2</micrometer.version>
+    <micrometer.version>1.8.4</micrometer.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 


### PR DESCRIPTION
Motivation:

Maintenance/ Keep dependencies up to date

