### PR TITLE
Rename request tags provider option for consistency

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -371,11 +371,11 @@ NOTE: Matchers use MeterFilters under the hood.
 
 === Custom tags provider
 
-You can define a function that generates additional tags (or labels) for HTTP server metrics.
+You can define a function that generates additional tags (or labels) for HTTP server or client metrics.
 Such function takes an {@link io.vertx.core.spi.observability.HttpRequest} object as a parameter, and returns
 an Iterable of {@link io.micrometer.core.instrument.Tag}.
 
-As an example, here is how to map the _x-user_ header to a custom label _user_:
+As an example, here is how to map the _x-user_ header to a custom label _user_ in both server and client metrics:
 
 [source,$lang]
 ----

--- a/src/main/java/examples/MicrometerMetricsExamples.java
+++ b/src/main/java/examples/MicrometerMetricsExamples.java
@@ -281,7 +281,11 @@ public class MicrometerMetricsExamples {
     Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
       new MicrometerMetricsOptions()
         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-        .setRequestsTagsProvider(req -> {
+        .setServerRequestTagsProvider(req -> {
+          String user = req.headers().get("x-user");
+          return Collections.singletonList(Tag.of("user", user));
+        })
+        .setClientRequestTagsProvider(req -> {
           String user = req.headers().get("x-user");
           return Collections.singletonList(Tag.of("user", user));
         })

--- a/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
+++ b/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
@@ -69,8 +69,8 @@ public class MicrometerMetricsOptions extends MetricsOptions {
   private VertxJmxMetricsOptions jmxMetricsOptions;
   private boolean jvmMetricsEnabled;
   private MetricsNaming metricsNaming;
-  private Function<HttpRequest, Iterable<Tag>> requestsTagsProvider;
-  private Function<HttpRequest, Iterable<Tag>> httpClientRequestsTagsProvider;
+  private Function<HttpRequest, Iterable<Tag>> serverRequestTagsProvider;
+  private Function<HttpRequest, Iterable<Tag>> clientRequestTagsProvider;
 
   /**
    * Creates default options for Micrometer metrics.
@@ -82,8 +82,8 @@ public class MicrometerMetricsOptions extends MetricsOptions {
     labelMatches = new ArrayList<>();
     jvmMetricsEnabled = DEFAULT_JVM_METRICS_ENABLED;
     metricsNaming = DEFAULT_METRICS_NAMING;
-    requestsTagsProvider = null;
-    httpClientRequestsTagsProvider = null;
+    serverRequestTagsProvider = null;
+    clientRequestTagsProvider = null;
   }
 
   /**
@@ -107,8 +107,8 @@ public class MicrometerMetricsOptions extends MetricsOptions {
     }
     jvmMetricsEnabled = other.jvmMetricsEnabled;
     metricsNaming = other.metricsNaming;
-    requestsTagsProvider = other.requestsTagsProvider;
-    httpClientRequestsTagsProvider = other.httpClientRequestsTagsProvider;
+    serverRequestTagsProvider = other.serverRequestTagsProvider;
+    clientRequestTagsProvider = other.clientRequestTagsProvider;
   }
 
   /**
@@ -426,43 +426,65 @@ public class MicrometerMetricsOptions extends MetricsOptions {
   }
 
   /**
-   * @return an optional custom tags provider for HTTP requests
+   * @return an optional custom tags provider for HTTP server requests
+   * @deprecated use {@code getServerRequestTagsProvider} instead
    */
   @GenIgnore
+  @Deprecated
   public Function<HttpRequest, Iterable<Tag>> getRequestsTagsProvider() {
-    return requestsTagsProvider;
+    return this.getServerRequestTagsProvider();
   }
 
   /**
-   * Sets a custom tags provider for HTTP requests. Allows to generate custom tags for every {@code HttpRequest} object processed through the metrics SPI.
+   * Sets a custom tags provider for HTTP server requests. Allows to generate custom tags for every {@code HttpRequest} object processed through the metrics SPI.
    *
-   * @param requestsTagsProvider an object implementing the {@code CustomTagsProvider} interface for {@code HttpRequest}.
+   * @param serverRequestTagsProvider an object implementing the {@code CustomTagsProvider} interface for {@code HttpRequest}.
+   * @return a reference to this, so that the API can be used fluently
+   * @deprecated use {@code setServerRequestTagsProvider} instead
+   */
+  @GenIgnore
+  @Deprecated
+  public MicrometerMetricsOptions setRequestsTagsProvider(Function<HttpRequest, Iterable<Tag>> serverRequestTagsProvider) {
+    return this.setServerRequestTagsProvider(serverRequestTagsProvider);
+  }
+
+  /**
+   * @return an optional custom tags provider for HTTP server requests
+   */
+  @GenIgnore
+  public Function<HttpRequest, Iterable<Tag>> getServerRequestTagsProvider() {
+    return serverRequestTagsProvider;
+  }
+
+  /**
+   * Sets a custom tags provider for HTTP server requests. Allows to generate custom tags for every {@code HttpRequest} object processed through the metrics SPI.
+   *
+   * @param serverRequestTagsProvider an object that returns an iterable of {@code Tag} for a {@code HttpRequest}.
    * @return a reference to this, so that the API can be used fluently
    */
   @GenIgnore
-  public MicrometerMetricsOptions setRequestsTagsProvider(Function<HttpRequest, Iterable<Tag>> requestsTagsProvider) {
-    this.requestsTagsProvider = requestsTagsProvider;
+  public MicrometerMetricsOptions setServerRequestTagsProvider(Function<HttpRequest, Iterable<Tag>> serverRequestTagsProvider) {
+    this.serverRequestTagsProvider = serverRequestTagsProvider;
     return this;
   }
 
   /**
-   * @return an optional custom tags provider for HTTP Client requests
+   * @return an optional custom tags provider for HTTP client requests
    */
   @GenIgnore
-  public Function<HttpRequest, Iterable<Tag>> getHttpClientRequestsTagsProvider() {
-    return httpClientRequestsTagsProvider;
+  public Function<HttpRequest, Iterable<Tag>> getClientRequestTagsProvider() {
+    return clientRequestTagsProvider;
   }
 
   /**
-   * Sets a custom tags provider for HTTP Client requests. Allows to generate custom tags for every {@code HttpRequest} object processed through the metrics SPI.
+   * Sets a custom tags provider for HTTP client requests. Allows to generate custom tags for every {@code HttpRequest} object processed through the metrics SPI.
    *
-   * @param httpClientRequestsTagsProvider an object that returns an iterable of {@code Tag} for a {@code HttpRequest}.
+   * @param clientRequestTagsProvider an object that returns an iterable of {@code Tag} for a {@code HttpRequest}.
    * @return a reference to this, so that the API can be used fluently
    */
   @GenIgnore
-  public MicrometerMetricsOptions setHttpClientRequestsTagsProvider(Function<HttpRequest, Iterable<Tag>> httpClientRequestsTagsProvider) {
-    this.httpClientRequestsTagsProvider = httpClientRequestsTagsProvider;
+  public MicrometerMetricsOptions setClientRequestTagsProvider(Function<HttpRequest, Iterable<Tag>> clientRequestTagsProvider) {
+    this.clientRequestTagsProvider = clientRequestTagsProvider;
     return this;
   }
-
 }

--- a/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
@@ -67,7 +67,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
   private final VertxHttpServerMetrics httpServerMetrics;
   private final VertxPoolMetrics poolMetrics;
   private final Map<String, VertxClientMetrics> mapClientMetrics = new ConcurrentHashMap<>();
-  private final Set<String> disabledCaterogies = new HashSet<>();
+  private final Set<String> disabledCategories = new HashSet<>();
 
   /**
    * @param options Vertx Prometheus options
@@ -78,7 +78,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     registryName = options.getRegistryName();
     MeterRegistry registry = backendRegistry.getMeterRegistry();
     if (options.getDisabledMetricsCategories() != null) {
-      disabledCaterogies.addAll(options.getDisabledMetricsCategories());
+      disabledCategories.addAll(options.getDisabledMetricsCategories());
     }
     names = options.getMetricsNaming();
 
@@ -91,9 +91,9 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     netServerMetrics = options.isMetricsCategoryDisabled(NET_SERVER) ? null
       : new VertxNetServerMetrics(registry, names);
     httpClientMetrics = options.isMetricsCategoryDisabled(HTTP_CLIENT) ? null
-      : new VertxHttpClientMetrics(registry, names, options.getHttpClientRequestsTagsProvider());
+      : new VertxHttpClientMetrics(registry, names, options.getClientRequestTagsProvider());
     httpServerMetrics = options.isMetricsCategoryDisabled(HTTP_SERVER) ? null
-      : new VertxHttpServerMetrics(registry, names, options.getRequestsTagsProvider());
+      : new VertxHttpServerMetrics(registry, names, options.getServerRequestTagsProvider());
     poolMetrics = options.isMetricsCategoryDisabled(NAMED_POOLS) ? null
       : new VertxPoolMetrics(registry, names);
   }
@@ -160,7 +160,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
 
   @Override
   public ClientMetrics<?, ?, ?, ?> createClientMetrics(SocketAddress remoteAddress, String type, String namespace) {
-    if (disabledCaterogies.contains(type)) {
+    if (disabledCategories.contains(type)) {
       return DummyVertxMetrics.DummyClientMetrics.INSTANCE;
     }
     VertxClientMetrics clientMetrics = mapClientMetrics.computeIfAbsent(type, t -> new VertxClientMetrics(registry, type, names));

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -42,7 +42,7 @@ public class VertxHttpClientServerMetricsTest {
   @Before
   public void setUp(TestContext ctx) {
     vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
-        .setHttpClientRequestsTagsProvider(req -> {
+        .setClientRequestTagsProvider(req -> {
           String user = req.headers().get("user");
           return user != null ? Collections.singletonList(Tag.of("user", user)) : Collections.emptyList();
         })

--- a/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
@@ -43,7 +43,7 @@ public class VertxHttpServerMetricsConfigTest {
   @Test
   public void shouldReportHttpServerMetricsWithCustomTags(TestContext ctx) {
     vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
-      .setRequestsTagsProvider(req -> {
+      .setServerRequestTagsProvider(req -> {
         String user = req.headers().get("user");
         return Collections.singletonList(Tag.of("user", user));
       })


### PR DESCRIPTION
Also:
- update doc
- keep but deprecate old option get/setter

It's a follow-up on https://github.com/vert-x3/vertx-micrometer-metrics/pull/135