### PR TITLE
Do not serialize access to gauge objects

### DIFF
--- a/src/main/java/io/vertx/micrometer/impl/AbstractMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/AbstractMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc.
+ * Copyright 2022 Red Hat, Inc.
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
 
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.MetricsDomain;
@@ -24,6 +25,7 @@ import io.vertx.micrometer.impl.meters.Gauges;
 import io.vertx.micrometer.impl.meters.Summaries;
 import io.vertx.micrometer.impl.meters.Timers;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -35,20 +37,24 @@ import java.util.concurrent.atomic.LongAdder;
 public abstract class AbstractMetrics implements MicrometerMetrics {
   protected final MeterRegistry registry;
   protected final String category;
+  protected final ConcurrentMap<Meter.Id, Object> gaugesTable;
 
-  AbstractMetrics(MeterRegistry registry) {
+  AbstractMetrics(MeterRegistry registry, ConcurrentMap<Meter.Id, Object> gaugesTable) {
     this.registry = registry;
+    this.gaugesTable = gaugesTable;
     this.category = null;
   }
 
-  AbstractMetrics(MeterRegistry registry, String category) {
+  AbstractMetrics(MeterRegistry registry, String category, ConcurrentMap<Meter.Id, Object> gaugesTable) {
     this.registry = registry;
     this.category = category;
+    this.gaugesTable = gaugesTable;
   }
 
-  AbstractMetrics(MeterRegistry registry, MetricsDomain domain) {
+  AbstractMetrics(MeterRegistry registry, MetricsDomain domain, ConcurrentMap<Meter.Id, Object> gaugesTable) {
     this.registry = registry;
     this.category = (domain == null) ? null : domain.toCategory();
+    this.gaugesTable = gaugesTable;
   }
 
   /**
@@ -69,11 +75,11 @@ public abstract class AbstractMetrics implements MicrometerMetrics {
   }
 
   Gauges<LongAdder> longGauges(String name, String description, Label... keys) {
-    return new Gauges<>(baseName() + name, description, LongAdder::new, LongAdder::doubleValue, registry, keys);
+    return new Gauges<>(gaugesTable, baseName() + name, description, LongAdder::new, LongAdder::doubleValue, registry, keys);
   }
 
   Gauges<AtomicReference<Double>> doubleGauges(String name, String description, Label... keys) {
-    return new Gauges<>(baseName() + name, description, () -> new AtomicReference<>(0d), AtomicReference::get, registry, keys);
+    return new Gauges<>(gaugesTable, baseName() + name, description, () -> new AtomicReference<>(0d), AtomicReference::get, registry, keys);
   }
 
   Summaries summaries(String name, String description, Label... keys) {

--- a/src/main/java/io/vertx/micrometer/impl/VertxClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxClientMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
 
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.ClientMetrics;
@@ -25,6 +26,7 @@ import io.vertx.micrometer.impl.meters.Counters;
 import io.vertx.micrometer.impl.meters.Gauges;
 import io.vertx.micrometer.impl.meters.Timers;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -37,8 +39,8 @@ class VertxClientMetrics extends AbstractMetrics {
   private final Gauges<LongAdder> processingPending;
   private final Counters resetCount;
 
-  VertxClientMetrics(MeterRegistry registry, String type, MetricsNaming names) {
-    super(registry, type);
+  VertxClientMetrics(MeterRegistry registry, String type, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, type, gaugesTable);
     queueDelay = timers(names.getClientQueueTime(), "Time spent in queue before being processed", Label.REMOTE, Label.NAMESPACE);
     queueSize = longGauges(names.getClientQueuePending(), "Number of pending elements in queue", Label.REMOTE, Label.NAMESPACE);
     processingTime = timers(names.getClientProcessingTime(), "Processing time, from request start to response end", Label.REMOTE, Label.NAMESPACE);

--- a/src/main/java/io/vertx/micrometer/impl/VertxDatagramSocketMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxDatagramSocketMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.DatagramSocketMetrics;
@@ -24,6 +25,8 @@ import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.MetricsNaming;
 import io.vertx.micrometer.impl.meters.Counters;
 import io.vertx.micrometer.impl.meters.Summaries;
+
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author Joel Takvorian
@@ -35,8 +38,8 @@ class VertxDatagramSocketMetrics extends AbstractMetrics implements DatagramSock
 
   private volatile String localAddress;
 
-  VertxDatagramSocketMetrics(MeterRegistry registry, MetricsNaming names) {
-    super(registry, MetricsDomain.DATAGRAM_SOCKET);
+  VertxDatagramSocketMetrics(MeterRegistry registry, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, MetricsDomain.DATAGRAM_SOCKET, gaugesTable);
     bytesReceived = summaries(names.getDatagramBytesRead(), "Total number of datagram bytes received", Label.LOCAL);
     bytesSent = summaries(names.getDatagramBytesWritten(), "Total number of datagram bytes sent");
     errorCount = counters(names.getDatagramErrorCount(), "Total number of datagram errors", Label.CLASS_NAME);

--- a/src/main/java/io/vertx/micrometer/impl/VertxEventBusMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxEventBusMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@
  */
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.ReplyFailure;
@@ -26,6 +27,7 @@ import io.vertx.micrometer.impl.meters.Counters;
 import io.vertx.micrometer.impl.meters.Gauges;
 import io.vertx.micrometer.impl.meters.Summaries;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -46,8 +48,8 @@ class VertxEventBusMetrics extends AbstractMetrics implements EventBusMetrics<Ve
   private final Summaries bytesRead;
   private final Summaries bytesWritten;
 
-  VertxEventBusMetrics(MeterRegistry registry, MetricsNaming names) {
-    super(registry, MetricsDomain.EVENT_BUS);
+  VertxEventBusMetrics(MeterRegistry registry, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, MetricsDomain.EVENT_BUS, gaugesTable);
     handlers = longGauges(names.getEbHandlers(), "Number of event bus handlers in use", Label.EB_ADDRESS);
     pending = longGauges(names.getEbPending(), "Number of messages not processed yet", Label.EB_ADDRESS, Label.EB_SIDE);
     processed = counters(names.getEbProcessed(), "Number of processed messages", Label.EB_ADDRESS, Label.EB_SIDE);

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
 
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.vertx.core.http.WebSocket;
@@ -32,6 +33,7 @@ import io.vertx.micrometer.impl.meters.Gauges;
 import io.vertx.micrometer.impl.meters.Summaries;
 import io.vertx.micrometer.impl.meters.Timers;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
@@ -50,8 +52,8 @@ class VertxHttpClientMetrics extends VertxNetClientMetrics {
   private final Gauges<LongAdder> wsConnections;
   private final Function<HttpRequest, Iterable<Tag>> customTagsProvider;
 
-  VertxHttpClientMetrics(MeterRegistry registry, MetricsNaming names, Function<HttpRequest, Iterable<Tag>> customTagsProvider) {
-    super(registry, MetricsDomain.HTTP_CLIENT, names);
+  VertxHttpClientMetrics(MeterRegistry registry, MetricsNaming names, Function<HttpRequest, Iterable<Tag>> customTagsProvider, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, MetricsDomain.HTTP_CLIENT, names, gaugesTable);
     this.customTagsProvider = customTagsProvider;
     queueDelay = timers(names.getHttpQueueTime(), "Time spent in queue before being processed", Label.LOCAL, Label.REMOTE);
     queueSize = longGauges(names.getHttpQueuePending(), "Number of pending elements in queue", Label.LOCAL, Label.REMOTE);

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@
  */
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.vertx.core.http.HttpMethod;
@@ -34,6 +35,7 @@ import io.vertx.micrometer.impl.meters.Timers;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
@@ -50,8 +52,8 @@ class VertxHttpServerMetrics extends VertxNetServerMetrics {
   private final Gauges<LongAdder> wsConnections;
   private final Function<HttpRequest, Iterable<Tag>> customTagsProvider;
 
-  VertxHttpServerMetrics(MeterRegistry registry, MetricsNaming names, Function<HttpRequest, Iterable<Tag>> customTagsProvider) {
-    super(registry, MetricsDomain.HTTP_SERVER, names);
+  VertxHttpServerMetrics(MeterRegistry registry, MetricsNaming names, Function<HttpRequest, Iterable<Tag>> customTagsProvider, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, MetricsDomain.HTTP_SERVER, names, gaugesTable);
     this.customTagsProvider = customTagsProvider;
     requests = longGauges(names.getHttpActiveRequests(), "Number of requests being processed", Label.LOCAL, Label.REMOTE, Label.HTTP_PATH, Label.HTTP_METHOD);
     requestCount = counters(names.getHttpRequestsCount(), "Number of processed requests", Label.LOCAL, Label.REMOTE, Label.HTTP_ROUTE, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE);

--- a/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
 
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.http.HttpClientOptions;
@@ -24,14 +25,7 @@ import io.vertx.core.metrics.impl.DummyVertxMetrics;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.DatagramSocketMetrics;
-import io.vertx.core.spi.metrics.EventBusMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
-import io.vertx.core.spi.metrics.HttpServerMetrics;
-import io.vertx.core.spi.metrics.PoolMetrics;
-import io.vertx.core.spi.metrics.TCPMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
+import io.vertx.core.spi.metrics.*;
 import io.vertx.micrometer.MetricsNaming;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.backends.BackendRegistries;
@@ -41,14 +35,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
-import static io.vertx.micrometer.MetricsDomain.DATAGRAM_SOCKET;
-import static io.vertx.micrometer.MetricsDomain.EVENT_BUS;
-import static io.vertx.micrometer.MetricsDomain.HTTP_CLIENT;
-import static io.vertx.micrometer.MetricsDomain.HTTP_SERVER;
-import static io.vertx.micrometer.MetricsDomain.NAMED_POOLS;
-import static io.vertx.micrometer.MetricsDomain.NET_CLIENT;
-import static io.vertx.micrometer.MetricsDomain.NET_SERVER;
+import static io.vertx.micrometer.MetricsDomain.*;
 
 /**
  * Metrics SPI implementation for Micrometer.
@@ -69,11 +58,8 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
   private final Map<String, VertxClientMetrics> mapClientMetrics = new ConcurrentHashMap<>();
   private final Set<String> disabledCategories = new HashSet<>();
 
-  /**
-   * @param options Vertx Prometheus options
-   */
-  public VertxMetricsImpl(MicrometerMetricsOptions options, BackendRegistry backendRegistry) {
-    super(backendRegistry.getMeterRegistry());
+  public VertxMetricsImpl(MicrometerMetricsOptions options, BackendRegistry backendRegistry, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(backendRegistry.getMeterRegistry(), gaugesTable);
     this.backendRegistry = backendRegistry;
     registryName = options.getRegistryName();
     MeterRegistry registry = backendRegistry.getMeterRegistry();
@@ -83,19 +69,19 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     names = options.getMetricsNaming();
 
     eventBusMetrics = options.isMetricsCategoryDisabled(EVENT_BUS) ? null
-      : new VertxEventBusMetrics(registry, names);
+      : new VertxEventBusMetrics(registry, names, gaugesTable);
     datagramSocketMetrics = options.isMetricsCategoryDisabled(DATAGRAM_SOCKET) ? null
-      : new VertxDatagramSocketMetrics(registry, names);
+      : new VertxDatagramSocketMetrics(registry, names, gaugesTable);
     netClientMetrics = options.isMetricsCategoryDisabled(NET_CLIENT) ? null
-      : new VertxNetClientMetrics(registry, names);
+      : new VertxNetClientMetrics(registry, names, gaugesTable);
     netServerMetrics = options.isMetricsCategoryDisabled(NET_SERVER) ? null
-      : new VertxNetServerMetrics(registry, names);
+      : new VertxNetServerMetrics(registry, names, gaugesTable);
     httpClientMetrics = options.isMetricsCategoryDisabled(HTTP_CLIENT) ? null
-      : new VertxHttpClientMetrics(registry, names, options.getClientRequestTagsProvider());
+      : new VertxHttpClientMetrics(registry, names, options.getClientRequestTagsProvider(), gaugesTable);
     httpServerMetrics = options.isMetricsCategoryDisabled(HTTP_SERVER) ? null
-      : new VertxHttpServerMetrics(registry, names, options.getServerRequestTagsProvider());
+      : new VertxHttpServerMetrics(registry, names, options.getServerRequestTagsProvider(), gaugesTable);
     poolMetrics = options.isMetricsCategoryDisabled(NAMED_POOLS) ? null
-      : new VertxPoolMetrics(registry, names);
+      : new VertxPoolMetrics(registry, names, gaugesTable);
   }
 
   void init() {
@@ -163,7 +149,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     if (disabledCategories.contains(type)) {
       return DummyVertxMetrics.DummyClientMetrics.INSTANCE;
     }
-    VertxClientMetrics clientMetrics = mapClientMetrics.computeIfAbsent(type, t -> new VertxClientMetrics(registry, type, names));
+    VertxClientMetrics clientMetrics = mapClientMetrics.computeIfAbsent(type, t -> new VertxClientMetrics(registry, type, names, gaugesTable));
     return clientMetrics.forInstance(remoteAddress, namespace);
   }
 

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
 
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.TCPMetrics;
@@ -25,6 +26,7 @@ import io.vertx.micrometer.MetricsNaming;
 import io.vertx.micrometer.impl.meters.Counters;
 import io.vertx.micrometer.impl.meters.Gauges;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -36,12 +38,12 @@ class VertxNetClientMetrics extends AbstractMetrics {
   private final Counters bytesSent;
   private final Counters errorCount;
 
-  VertxNetClientMetrics(MeterRegistry registry, MetricsNaming names) {
-    this(registry, MetricsDomain.NET_CLIENT, names);
+  VertxNetClientMetrics(MeterRegistry registry, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    this(registry, MetricsDomain.NET_CLIENT, names, gaugesTable);
   }
 
-  VertxNetClientMetrics(MeterRegistry registry, MetricsDomain domain, MetricsNaming names) {
-    super(registry, domain);
+  VertxNetClientMetrics(MeterRegistry registry, MetricsDomain domain, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, domain, gaugesTable);
     connections = longGauges(names.getNetActiveConnections(), "Number of connections to the remote host currently opened", Label.LOCAL, Label.REMOTE);
     bytesReceived = counters(names.getNetBytesRead(), "Number of bytes received from the remote host", Label.LOCAL, Label.REMOTE);
     bytesSent = counters(names.getNetBytesWritten(), "Number of bytes sent to the remote host", Label.LOCAL, Label.REMOTE);

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@
  */
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.TCPMetrics;
@@ -24,6 +25,7 @@ import io.vertx.micrometer.MetricsNaming;
 import io.vertx.micrometer.impl.meters.Counters;
 import io.vertx.micrometer.impl.meters.Gauges;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -35,12 +37,12 @@ class VertxNetServerMetrics extends AbstractMetrics {
   private final Counters bytesSent;
   private final Counters errorCount;
 
-  VertxNetServerMetrics(MeterRegistry registry, MetricsNaming names) {
-    this(registry, MetricsDomain.NET_SERVER, names);
+  VertxNetServerMetrics(MeterRegistry registry, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    this(registry, MetricsDomain.NET_SERVER, names, gaugesTable);
   }
 
-  VertxNetServerMetrics(MeterRegistry registry, MetricsDomain domain, MetricsNaming names) {
-    super(registry, domain);
+  VertxNetServerMetrics(MeterRegistry registry, MetricsDomain domain, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, domain, gaugesTable);
     connections = longGauges(names.getNetActiveConnections(), "Number of opened connections to the server", Label.LOCAL, Label.REMOTE);
     bytesReceived = counters(names.getNetBytesRead(), "Number of bytes received by the server", Label.LOCAL, Label.REMOTE);
     bytesSent = counters(names.getNetBytesWritten(), "Number of bytes sent by the server", Label.LOCAL, Label.REMOTE);

--- a/src/main/java/io/vertx/micrometer/impl/VertxPoolMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxPoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
+ * Copyright (c) 2011-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
 
 package io.vertx.micrometer.impl;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.micrometer.Label;
@@ -25,6 +26,7 @@ import io.vertx.micrometer.impl.meters.Counters;
 import io.vertx.micrometer.impl.meters.Gauges;
 import io.vertx.micrometer.impl.meters.Timers;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -39,8 +41,8 @@ class VertxPoolMetrics extends AbstractMetrics {
   private final Gauges<AtomicReference<Double>> usageRatio;
   private final Counters completed;
 
-  VertxPoolMetrics(MeterRegistry registry, MetricsNaming names) {
-    super(registry, MetricsDomain.NAMED_POOLS);
+  VertxPoolMetrics(MeterRegistry registry, MetricsNaming names, ConcurrentMap<Meter.Id, Object> gaugesTable) {
+    super(registry, MetricsDomain.NAMED_POOLS, gaugesTable);
     queueDelay = timers(names.getPoolQueueTime(), "Time spent in queue before being processed", Label.POOL_TYPE, Label.POOL_NAME);
     queueSize = longGauges(names.getPoolQueuePending(), "Number of pending elements in queue", Label.POOL_TYPE, Label.POOL_NAME);
     usage = timers(names.getPoolUsage(), "Time using a resource", Label.POOL_TYPE, Label.POOL_NAME);

--- a/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,23 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.vertx.micrometer.impl.meters;
 
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.*;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.impl.Labels;
 
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * @author Joel Takvorian
@@ -42,14 +35,16 @@ public class Gauges<T> {
   private final Supplier<T> tSupplier;
   private final ToDoubleFunction<T> dGetter;
   private final MeterRegistry registry;
-  private final Map<Meter.Id, T> gauges = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Meter.Id, Object> gauges;
 
-  public Gauges(String name,
+  public Gauges(ConcurrentMap<Meter.Id, Object> gauges,
+                String name,
                 String description,
                 Supplier<T> tSupplier,
                 ToDoubleFunction<T> dGetter,
                 MeterRegistry registry,
                 Label... keys) {
+    this.gauges = gauges;
     this.name = name;
     this.description = description;
     this.tSupplier = tSupplier;
@@ -62,21 +57,50 @@ public class Gauges<T> {
     return get(null, values);
   }
 
-  public synchronized T get(Iterable<Tag> customTags, String... values) {
-    List<Tag> tags = customTags != null
-      ? Stream.concat(Labels.toTags(keys, values).stream(), StreamSupport.stream(customTags.spliterator(), false)).collect(Collectors.toList())
-      : Labels.toTags(keys, values);
-    // This method is synchronized to make sure the "T" built via supplier will match the one passed to Gauge
-    //  since it is stored as WeakReference in Micrometer DefaultGauge, it must not be lost.
-    T t = tSupplier.get();
-    // Register this gauge if necessary
-    // Note: we need here to go through the process of Gauge creation, even if it already exists,
-    //  in order to get the Gauge ID. This ID generation is not trivial since it may involves attached MetricFilters.
-    //  Micrometer will not register the gauge twice if it was already created.
-    Gauge g = Gauge.builder(name, t, dGetter)
+  @SuppressWarnings("unchecked")
+  public T get(Iterable<Tag> customTags, String... values) {
+    Tags tags = Tags.of(Labels.toTags(keys, values)).and(customTags);
+    T candidate = tSupplier.get();
+    ToDoubleFunc<T> candidateFunc = new ToDoubleFunc<>(dGetter);
+    Gauge gauge = Gauge.builder(name, candidate, candidateFunc)
       .description(description)
       .tags(tags)
       .register(registry);
-    return gauges.computeIfAbsent(g.getId(), v -> t);
+    Meter.Id gaugeId = gauge.getId();
+    Object res;
+    for (; ; ) {
+      res = gauges.get(gaugeId);
+      if (res != null) {
+        break;
+      }
+      ensureGetterInvoked(gauge);
+      if (candidateFunc.invoked) {
+        gauges.put(gaugeId, candidate);
+        res = candidate;
+        break;
+      }
+    }
+    return (T) res;
+  }
+
+  private void ensureGetterInvoked(Gauge gauge) {
+    gauge.value();
+  }
+
+  private static class ToDoubleFunc<R> implements ToDoubleFunction<R> {
+    final ToDoubleFunction<R> delegate;
+    volatile boolean invoked;
+
+    ToDoubleFunc(ToDoubleFunction<R> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public double applyAsDouble(R value) {
+      if (!invoked) {
+        invoked = true;
+      }
+      return delegate.applyAsDouble(value);
+    }
   }
 }

--- a/src/test/java/io/vertx/micrometer/impl/meters/GaugesTest.java
+++ b/src/test/java/io/vertx/micrometer/impl/meters/GaugesTest.java
@@ -1,6 +1,24 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.micrometer.impl.meters;
 
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -14,6 +32,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +45,8 @@ public class GaugesTest {
 
   private static final EnumSet<Label> ALL_LABELS = EnumSet.allOf(Label.class);
 
+  ConcurrentMap<Meter.Id, Object> gaugesTable = new ConcurrentHashMap<>();
+
   @Test
   public void shouldAliasGaugeLabel() {
     MeterRegistry registry = new SimpleMeterRegistry();
@@ -33,16 +55,16 @@ public class GaugesTest {
       .setType(MatchType.REGEX)
       .setValue("addr1")
       .setAlias("1")));
-    Gauges<LongAdder> gauges = new Gauges<>("my_gauge", "", LongAdder::new, LongAdder::doubleValue, registry, Label.EB_ADDRESS);
+    Gauges<LongAdder> gauges = new Gauges<>(gaugesTable, "my_gauge", "", LongAdder::new, LongAdder::doubleValue, registry, Label.EB_ADDRESS);
     gauges.get("addr1").increment();
     gauges.get("addr1").increment();
     gauges.get("addr2").increment();
 
-    Gauge g = registry.find("my_gauge").tags("address", "1").gauge();
+    Gauge g = registry.get("my_gauge").tags("address", "1").gauge();
     assertThat(g.value()).isEqualTo(2d);
     g = registry.find("my_gauge").tags("address", "addr1").gauge();
     assertThat(g).isNull();
-    g = registry.find("my_gauge").tags("address", "addr2").gauge();
+    g = registry.get("my_gauge").tags("address", "addr2").gauge();
     assertThat(g.value()).isEqualTo(1d);
   }
 
@@ -54,12 +76,12 @@ public class GaugesTest {
       .setType(MatchType.REGEX)
       .setValue(".*")
       .setAlias("_")));
-    Gauges<LongAdder> gauges = new Gauges<>("my_gauge", "", LongAdder::new, LongAdder::doubleValue, registry, Label.EB_ADDRESS);
+    Gauges<LongAdder> gauges = new Gauges<>(gaugesTable, "my_gauge", "", LongAdder::new, LongAdder::doubleValue, registry, Label.EB_ADDRESS);
     gauges.get("addr1").increment();
     gauges.get("addr1").increment();
     gauges.get("addr2").increment();
 
-    Gauge g = registry.find("my_gauge").tags("address", "_").gauge();
+    Gauge g = registry.get("my_gauge").tags("address", "_").gauge();
     assertThat(g.value()).isEqualTo(3d);
     g = registry.find("my_gauge").tags("address", "addr1").gauge();
     assertThat(g).isNull();
@@ -71,10 +93,10 @@ public class GaugesTest {
   public void shouldAddCustomTags() {
     List<Tag> customTags = Arrays.asList(Tag.of("k1", "v1"), Tag.of("k2", "v2"));
     MeterRegistry registry = new SimpleMeterRegistry();
-    Gauges<LongAdder> gauges = new Gauges<>("my_gauge", "", LongAdder::new, LongAdder::doubleValue, registry, Label.EB_ADDRESS);
+    Gauges<LongAdder> gauges = new Gauges<>(gaugesTable, "my_gauge", "", LongAdder::new, LongAdder::doubleValue, registry, Label.EB_ADDRESS);
     gauges.get(customTags, "addr1").increment();
 
-    Gauge g = registry.find("my_gauge").tags("address", "addr1", "k1", "v1", "k2", "v2").gauge();
+    Gauge g = registry.get("my_gauge").tags("address", "addr1", "k1", "v1", "k2", "v2").gauge();
     assertThat(g.value()).isEqualTo(1d);
   }
 }


### PR DESCRIPTION
Fixes #91

Micrometer does not let us access the object that is referenced in a gauge. For this reason, we have to put such objects in a map which keys are the gauge id.
(Note: we have to do this because our gauges are computed dynamically with the provided tags.)

So far, to avoid race conditions, the access to gauges has been serialized. But that comes with an important performance impact.

The solution proposed here consists in using:

- a non-blocking construct instead of synchronization
- having a single gaugesTable for all Gauges object instance (multiple Gauges instances can try to create the same gauge concurrently)

Also, sometimes multiples Vert.x instances can be created in the same JVM. A good practice is to provide a name to the registry using MetricsOptions, but if the user does not, the same registry (can be used to store data).
That is why we need to store the gaugesTable in static map in VertxMetricsFactoryImpl.