### PR TITLE
Make sure all tests use a different registry

### DIFF
--- a/src/test/java/io/vertx/micrometer/MatchersTest.java
+++ b/src/test/java/io/vertx/micrometer/MatchersTest.java
@@ -1,27 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.micrometer;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.WorkerExecutor;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.backends.BackendRegistries;
 import io.vertx.micrometer.impl.meters.Counters;
-import org.assertj.core.util.DoubleComparator;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumSet;
-import java.util.List;
 
-import static io.vertx.micrometer.RegistryInspector.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**

--- a/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpClientServerMetricsTest.java
@@ -2,7 +2,9 @@ package io.vertx.micrometer;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.MeterFilter;
-import io.vertx.core.*;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
@@ -10,24 +12,20 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.backends.BackendRegistries;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
 
-import static io.vertx.micrometer.RegistryInspector.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Joel Takvorian
  */
 @RunWith(VertxUnitRunner.class)
-public class VertxHttpClientServerMetricsTest {
+public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase {
 
   private static final int HTTP_SENT_COUNT = 68;
   private static final String SERVER_RESPONSE = "some text";
@@ -35,22 +33,22 @@ public class VertxHttpClientServerMetricsTest {
   private static final long REQ_DELAY = 30L;
 
   private final int concurrentClients = ForkJoinPool.commonPool().getParallelism();
-  private final String registryName = UUID.randomUUID().toString();
   private HttpServer httpServer;
-  private Vertx vertx;
 
-  @Before
-  public void setUp(TestContext ctx) {
-    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
-        .setClientRequestTagsProvider(req -> {
-          String user = req.headers().get("user");
-          return user != null ? Collections.singletonList(Tag.of("user", user)) : Collections.emptyList();
-        })
-        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-        .setRegistryName(registryName)
-        .addLabels(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.EB_ADDRESS)
-        .setEnabled(true)))
-        .exceptionHandler(ctx.exceptionHandler());
+  @Override
+  protected MicrometerMetricsOptions metricOptions() {
+    return super.metricOptions()
+      .setClientRequestTagsProvider(req -> {
+        String user = req.headers().get("user");
+        return user != null ? Collections.singletonList(Tag.of("user", user)) : Collections.emptyList();
+      })
+      .addLabels(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.EB_ADDRESS);
+  }
+
+  @Override
+  protected void setUp(TestContext ctx) {
+    super.setUp(ctx);
+    vertx = vertx(ctx);
 
     // Filter out remote labels
     BackendRegistries.getNow(registryName).config().meterFilter(
@@ -87,19 +85,14 @@ public class VertxHttpClientServerMetricsTest {
     serverReady.awaitSuccess();
   }
 
-  @After
-  public void tearDown(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
-  }
-
   @Test
   public void shouldReportHttpClientMetrics(TestContext ctx) {
     runClientRequests(ctx, false, "jordi");
 
-    waitForValue(vertx, ctx, registryName, "vertx.http.client.bytes.read[local=?,remote=127.0.0.1:9195]$COUNT",
+    waitForValue(ctx, "vertx.http.client.bytes.read[local=?,remote=127.0.0.1:9195]$COUNT",
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length);
 
-    List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.client."));
+    List<Datapoint> datapoints = listDatapoints(startsWith("vertx.http.client."));
     assertThat(datapoints).hasSize(17).contains(
         dp("vertx.http.client.queue.pending[local=?,remote=127.0.0.1:9195]$VALUE", 0),
         dp("vertx.http.client.queue.time[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT),
@@ -124,10 +117,10 @@ public class VertxHttpClientServerMetricsTest {
   public void shouldReportHttpServerMetricsWithoutWS(TestContext ctx) {
     runClientRequests(ctx, false, null);
 
-    waitForValue(vertx, ctx, registryName, "vertx.http.server.bytes.read[local=127.0.0.1:9195,remote=_]$COUNT",
+    waitForValue(ctx, "vertx.http.server.bytes.read[local=127.0.0.1:9195,remote=_]$COUNT",
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length);
 
-    List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.server."));
+    List<Datapoint> datapoints = listDatapoints(startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).containsOnly(
       "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       "vertx.http.server.active.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$VALUE",
@@ -157,10 +150,10 @@ public class VertxHttpClientServerMetricsTest {
     runClientRequests(ctx, true, null);
 
     // Remark, with websockets, two extra requests are performed so increase the expected value
-    waitForValue(vertx, ctx, registryName, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
+    waitForValue(ctx, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
 
-    List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.server."));
+    List<Datapoint> datapoints = listDatapoints(startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).containsOnly(
       "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       "vertx.http.server.active.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$VALUE",
@@ -191,10 +184,10 @@ public class VertxHttpClientServerMetricsTest {
   public void shouldIgnoreInternalEventbusMetrics(TestContext ctx) {
     runClientRequests(ctx, true, null);
 
-    waitForValue(vertx, ctx, registryName, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
+    waitForValue(ctx, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,route=MyRoute]$COUNT",
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
 
-    List<RegistryInspector.Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.eventbus."));
+    List<Datapoint> datapoints = listDatapoints(startsWith("vertx.eventbus."));
     assertThat(datapoints).isEmpty();
   }
 

--- a/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
@@ -4,65 +4,52 @@ import io.micrometer.core.instrument.Tag;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
-import static io.vertx.micrometer.RegistryInspector.Datapoint;
-import static io.vertx.micrometer.RegistryInspector.listDatapoints;
-import static io.vertx.micrometer.RegistryInspector.startsWith;
-import static io.vertx.micrometer.RegistryInspector.waitForValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Joel Takvorian
  */
 @RunWith(VertxUnitRunner.class)
-public class VertxHttpServerMetricsConfigTest {
-  private final String registryName = UUID.randomUUID().toString();
-  private HttpServer httpServer;
-  private Vertx vertx;
+public class VertxHttpServerMetricsConfigTest extends MicrometerMetricsTestBase {
 
-  @After
-  public void tearDown(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
+  private HttpServer httpServer;
+
+  @Override
+  protected MicrometerMetricsOptions metricOptions() {
+    return super.metricOptions()
+      .setServerRequestTagsProvider(req -> {
+        String user = req.headers().get("user");
+        return Collections.singletonList(Tag.of("user", user));
+      });
   }
 
   @Test
   public void shouldReportHttpServerMetricsWithCustomTags(TestContext ctx) {
-    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MicrometerMetricsOptions()
-      .setServerRequestTagsProvider(req -> {
-        String user = req.headers().get("user");
-        return Collections.singletonList(Tag.of("user", user));
-      })
-      .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-      .setRegistryName(registryName)
-      .setEnabled(true)))
-      .exceptionHandler(ctx.exceptionHandler());
+    vertx = vertx(ctx);
 
     prepareServer(ctx);
     HttpClient client = vertx.createHttpClient();
     sendRequest(ctx, client, "alice");
     sendRequest(ctx, client, "bob");
 
-    waitForValue(vertx, ctx, registryName, "vertx.http.client.response.time[code=200,method=POST]$COUNT",
+    waitForValue(ctx, "vertx.http.client.response.time[code=200,method=POST]$COUNT",
       value -> value.intValue() == 2);
-    waitForValue(vertx, ctx, registryName, "vertx.http.client.active.requests[method=POST]$VALUE",
+    waitForValue(ctx, "vertx.http.client.active.requests[method=POST]$VALUE",
       value -> value.intValue() == 0);
 
-    List<Datapoint> datapoints = listDatapoints(registryName, startsWith("vertx.http.server."));
+    List<Datapoint> datapoints = listDatapoints(startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).contains(
       "vertx.http.server.requests[code=200,method=POST,route=,user=alice]$COUNT",
       "vertx.http.server.active.requests[method=POST,user=alice]$VALUE",

--- a/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/InfluxDbReporterITest.java
@@ -18,29 +18,24 @@ package io.vertx.micrometer.backend;
 
 
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.MicrometerMetricsTestBase;
 import io.vertx.micrometer.VertxInfluxDbOptions;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @RunWith(VertxUnitRunner.class)
-public class InfluxDbReporterITest {
+public class InfluxDbReporterITest extends MicrometerMetricsTestBase {
 
-  private static final String REGITRY_NAME = "InfluxDbReporterITest";
-  private Vertx vertx;
   private Vertx vertxForSimulatedServer = Vertx.vertx();
 
-  @After
-  public void after(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
+  @Override
+  protected void tearDown(TestContext context) {
+    super.tearDown(context);
     vertxForSimulatedServer.close(context.asyncAssertSuccess());
   }
 
@@ -54,15 +49,16 @@ public class InfluxDbReporterITest {
       }
     });
 
-    vertx = Vertx.vertx(new VertxOptions()
-      .setMetricsOptions(new MicrometerMetricsOptions()
-        .setInfluxDbOptions(new VertxInfluxDbOptions()
-          .setStep(1)
-          .setDb("mydb")
-          .setEnabled(true))
-        .setRegistryName(REGITRY_NAME)
-        .addLabels(Label.EB_ADDRESS)
-        .setEnabled(true)));
+    metricsOptions = new MicrometerMetricsOptions()
+      .setInfluxDbOptions(new VertxInfluxDbOptions()
+        .setStep(1)
+        .setDb("mydb")
+        .setEnabled(true))
+      .setRegistryName(registryName)
+      .addLabels(Label.EB_ADDRESS)
+      .setEnabled(true);
+
+    vertx = vertx(context);
 
     // Send something on the eventbus and wait til it's received
     Async asyncEB = context.async();

--- a/src/test/java/io/vertx/micrometer/backend/JmxMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/JmxMetricsITest.java
@@ -16,15 +16,13 @@
 
 package io.vertx.micrometer.backend;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.MicrometerMetricsTestBase;
 import io.vertx.micrometer.VertxJmxMetricsOptions;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -35,26 +33,19 @@ import java.lang.management.ManagementFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(VertxUnitRunner.class)
-public class JmxMetricsITest {
-
-  private static final String REGISTRY_NAME = "jmx-test";
-  private Vertx vertx;
-
-  @After
-  public void tearDown(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
-  }
+public class JmxMetricsITest extends MicrometerMetricsTestBase {
 
   @Test
   public void shouldReportJmx(TestContext context) throws Exception {
-    vertx = Vertx.vertx(new VertxOptions()
-      .setMetricsOptions(new MicrometerMetricsOptions()
-        .setRegistryName(REGISTRY_NAME)
-        .addLabels(Label.EB_ADDRESS)
-        .setJmxMetricsOptions(new VertxJmxMetricsOptions().setEnabled(true)
-          .setDomain("my-metrics")
-          .setStep(1))
-        .setEnabled(true)));
+    metricsOptions = new MicrometerMetricsOptions()
+      .setRegistryName(registryName)
+      .addLabels(Label.EB_ADDRESS)
+      .setJmxMetricsOptions(new VertxJmxMetricsOptions().setEnabled(true)
+        .setDomain("my-metrics")
+        .setStep(1))
+      .setEnabled(true);
+
+    vertx = vertx(context);
 
     // Send something on the eventbus and wait til it's received
     Async asyncEB = context.async();


### PR DESCRIPTION
Fixes #139 

Using different registries avoids having clashes in meter names that can results in intermittent failures.