### PR TITLE
Reduce allocations

### DIFF
--- a/src/main/java/io/vertx/micrometer/Label.java
+++ b/src/main/java/io/vertx/micrometer/Label.java
@@ -79,7 +79,7 @@ public enum Label {
    */
   NAMESPACE("client_namespace");
 
-  private String labelOutput;
+  private final String labelOutput;
 
   Label(String labelOutput) {
     this.labelOutput = labelOutput;

--- a/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
+++ b/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
@@ -18,6 +18,7 @@ package io.vertx.micrometer.backends;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.micrometer.Label;
@@ -27,6 +28,7 @@ import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxInfluxDbOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.*;
 
 /**
  * {@link BackendRegistries} is responsible for managing registries related to particular micrometer backends (influxdb, prometheus...)
@@ -116,10 +120,12 @@ public final class BackendRegistries {
   }
 
   public static void registerMatchers(MeterRegistry registry, Set<Label> enabledLabels, List<Match> matches) {
-    String[] ignored = EnumSet.complementOf(EnumSet.copyOf(enabledLabels)).stream()
+    Set<String> ignored = EnumSet.complementOf(EnumSet.copyOf(enabledLabels)).stream()
       .map(Label::toString)
-      .toArray(String[]::new);
-    registry.config().meterFilter(MeterFilter.ignoreTags(ignored));
+      .collect(toSet());
+    if (!ignored.isEmpty()) {
+      registry.config().meterFilter(ignoreTags(ignored));
+    }
     matches.forEach(m -> {
       switch (m.getType()) {
         case EQUALS:
@@ -178,6 +184,23 @@ public final class BackendRegistries {
           break;
       }
     });
+  }
+
+  private static MeterFilter ignoreTags(Set<String> ignored) {
+    return new MeterFilter() {
+      @Override
+      public Meter.Id map(Meter.Id id) {
+        List<Tag> tags = new ArrayList<>();
+        int count = 0;
+        for (Tag tag : id.getTagsAsIterable()) {
+          if (!ignored.contains(tag.getKey())) {
+            tags.add(tag);
+          }
+          count++;
+        }
+        return tags.size() == count ? id : id.replaceTags(tags);
+      }
+    };
   }
 
   private static MeterFilter replaceTagValues(MetricsDomain domain, String tagKey, Function<String, String> replacement) {

--- a/src/main/java/io/vertx/micrometer/impl/Labels.java
+++ b/src/main/java/io/vertx/micrometer/impl/Labels.java
@@ -16,10 +16,11 @@
  */
 package io.vertx.micrometer.impl;
 
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.micrometer.Label;
+
+import java.util.Arrays;
 
 /**
  * @author Joel Takvorian
@@ -55,13 +56,23 @@ public final class Labels {
       return Tags.empty();
     }
     // Creating a Tags object is faster and consumes less resources when providing an array
-    Tag[] tags = new Tag[keys.length];
+    String[] keyValuePairs = new String[2 * keys.length];
+    int count = 0;
     for (int i = 0; i < keys.length; i++) {
-      if (values[i] != null) {
+      String value = values[i];
+      if (value != null) {
         String lowKey = keys[i].toString();
-        tags[i] = Tag.of(lowKey, values[i]);
+        keyValuePairs[2 * count] = lowKey;
+        keyValuePairs[2 * count + 1] = value;
+        count++;
       }
     }
-    return Tags.of(tags);
+    if (count == 0) {
+      return Tags.empty();
+    }
+    if (count == keys.length) {
+      return Tags.of(keyValuePairs);
+    }
+    return Tags.of(Arrays.copyOf(keyValuePairs, 2 * count));
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/Labels.java
+++ b/src/main/java/io/vertx/micrometer/impl/Labels.java
@@ -17,12 +17,9 @@
 package io.vertx.micrometer.impl;
 
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.micrometer.Label;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * @author Joel Takvorian
@@ -51,17 +48,20 @@ public final class Labels {
     return local ? "local" : "remote";
   }
 
-  public static List<Tag> toTags(Label[] keys, String[] values) {
+  public static Tags toTags(Label[] keys, String[] values) {
+    // Here we shall use Tags object instead of List.
+    // Otherwise, some extra copies / iterations will be made
     if (keys.length == 0) {
-      return Collections.emptyList();
+      return Tags.empty();
     }
-    List<Tag> tags = new ArrayList<>(keys.length);
+    // Creating a Tags object is faster and consumes less resources when providing an array
+    Tag[] tags = new Tag[keys.length];
     for (int i = 0; i < keys.length; i++) {
       if (values[i] != null) {
         String lowKey = keys[i].toString();
-        tags.add(Tag.of(lowKey, values[i]));
+        tags[i] = Tag.of(lowKey, values[i]);
       }
     }
-    return tags;
+    return Tags.of(tags);
   }
 }

--- a/src/main/java/io/vertx/micrometer/impl/meters/Counters.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Counters.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.vertx.micrometer.Label;
-import io.vertx.micrometer.impl.Labels;
 
 /**
  * @author Joel Takvorian
@@ -47,7 +46,7 @@ public class Counters {
   }
 
   public Counter get(Iterable<Tag> customTags, String... values) {
-    Tags tags = Tags.of(Labels.toTags(keys, values)).and(customTags);
+    Tags tags = TagsCache.getOrCreate(customTags, keys, values);
     return Counter.builder(name)
       .description(description)
       .tags(tags)

--- a/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
@@ -22,6 +22,8 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.micrometer.Label;
 
 import java.util.concurrent.ConcurrentMap;
@@ -33,6 +35,9 @@ import java.util.function.ToDoubleFunction;
  * @author Joel Takvorian
  */
 public class Gauges<T> {
+
+  private static final Object VALUE_SUPPLIER = new Object();
+
   private final String name;
   private final String description;
   private final Label[] keys;
@@ -64,15 +69,40 @@ public class Gauges<T> {
   @SuppressWarnings("unchecked")
   public T get(Iterable<Tag> customTags, String... values) {
     Tags tags = TagsCache.getOrCreate(customTags, keys, values);
-    ValueSupplier<T> supplier = new ValueSupplier<>(gauges, dGetter);
-    Gauge gauge = Gauge.builder(name, supplier)
+    ContextInternal context = (ContextInternal) Vertx.currentContext();
+    ValueSupplier<T> valueSupplier = getOrCreateValueSupplier(context);
+    Gauge gauge = Gauge.builder(name, valueSupplier)
       .description(description)
       .tags(tags)
       .strongReference(true)
       .register(registry);
     Meter.Id meterId = gauge.getId();
-    supplier.id = meterId;
-    return (T) gauges.computeIfAbsent(meterId, tSupplier);
+    T res = (T) gauges.get(meterId);
+    if (res == null) {
+      T candidate = tSupplier.apply(meterId);
+      if ((res = (T) gauges.putIfAbsent(meterId, candidate)) == null) {
+        res = candidate;
+        valueSupplier.id = meterId;
+        return res;
+      }
+    }
+    recycleValueSupplier(context, valueSupplier);
+    return res;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ValueSupplier<T> getOrCreateValueSupplier(ContextInternal context) {
+    ValueSupplier<T> res;
+    if (context == null || (res = (ValueSupplier<T>) context.contextData().get(VALUE_SUPPLIER)) == null) {
+      res = new ValueSupplier<>(gauges, dGetter);
+    }
+    return res;
+  }
+
+  private void recycleValueSupplier(ContextInternal context, ValueSupplier<T> valueSupplier) {
+    if (context != null) {
+      context.contextData().put(VALUE_SUPPLIER, valueSupplier);
+    }
   }
 
   private static class ValueSupplier<G> implements Supplier<Number> {

--- a/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
@@ -17,9 +17,12 @@
 
 package io.vertx.micrometer.impl.meters;
 
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.vertx.micrometer.Label;
-import io.vertx.micrometer.impl.Labels;
 
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -60,7 +63,7 @@ public class Gauges<T> {
 
   @SuppressWarnings("unchecked")
   public T get(Iterable<Tag> customTags, String... values) {
-    Tags tags = Tags.of(Labels.toTags(keys, values)).and(customTags);
+    Tags tags = TagsCache.getOrCreate(customTags, keys, values);
     ValueSupplier<T> supplier = new ValueSupplier<>(gauges, dGetter);
     Gauge gauge = Gauge.builder(name, supplier)
       .description(description)

--- a/src/main/java/io/vertx/micrometer/impl/meters/Summaries.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Summaries.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.vertx.micrometer.Label;
-import io.vertx.micrometer.impl.Labels;
 
 /**
  * @author Joel Takvorian
@@ -47,7 +46,7 @@ public class Summaries {
   }
 
   public DistributionSummary get(Iterable<Tag> customTags, String... values) {
-    Tags tags = Tags.of(Labels.toTags(keys, values)).and(customTags);
+    Tags tags = TagsCache.getOrCreate(customTags, keys, values);
     return DistributionSummary.builder(name)
       .description(description)
       .tags(tags)

--- a/src/main/java/io/vertx/micrometer/impl/meters/TagsCache.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/TagsCache.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.micrometer.impl.meters;
+
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.micrometer.Label;
+import io.vertx.micrometer.impl.Labels;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * Cache {@link Tags} in Vert.x contexts.
+ * Each Vert.x context gets its own cache to avoid concurrency complications.
+ * In case this cache is called on a non-Vert.x thread, a new instance of {@link Tags} is returned.
+ */
+public class TagsCache {
+
+  // To avoid creating cache keys on each lookup, a flyweight is stored in the Vert.x context
+  // It is possible to have this flyweight because the caller is either on an event loop context or a worker context
+  // Never two workers will request a Tags instance on the same context concurrently
+  private static final Object TAGS_DATA_FLYWEIGHT = new Object();
+  // Used to store the per-context Tags cache
+  private static final Object CACHE = new Object();
+
+  public static Tags getOrCreate(Iterable<Tag> customTags, Label[] keys, String[] values) {
+    ContextInternal context = (ContextInternal) Vertx.currentContext();
+    if (context == null) {
+      return createTags(customTags, keys, values);
+    }
+    Map<TagsData, Tags> cache = cache(context);
+    try (TagsData cacheKey = flyweightKey(context, customTags, keys, values)) {
+      Tags tags = cache.get(cacheKey);
+      if (tags == null) {
+        tags = createTags(customTags, keys, values);
+        cache.put(cacheKey.copy(), tags);
+      }
+      return tags;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<TagsData, Tags> cache(ContextInternal context) {
+    return (Map<TagsData, Tags>) context.contextData().computeIfAbsent(CACHE, v -> lruMap());
+  }
+
+  private static TagsData flyweightKey(ContextInternal context, Iterable<Tag> customTags, Label[] keys, String[] values) {
+    TagsData tagsData = (TagsData) context.contextData().computeIfAbsent(TAGS_DATA_FLYWEIGHT, v -> new TagsData());
+    tagsData.init(customTags, keys, values);
+    return tagsData;
+  }
+
+  private static Tags createTags(Iterable<Tag> customTags, Label[] keys, String[] values) {
+    return Labels.toTags(keys, values).and(customTags);
+  }
+
+  private static LinkedHashMap<TagsData, Tags> lruMap() {
+    return new LinkedHashMap<TagsData, Tags>() {
+      @Override
+      protected boolean removeEldestEntry(Map.Entry eldest) {
+        return size() > 512;
+      }
+    };
+  }
+
+  // Visible for testing
+  final static class TagsData implements AutoCloseable {
+    Iterable<Tag> customTags;
+    Label[] keys;
+    String[] values;
+
+    TagsData() {
+    }
+
+    TagsData(Iterable<Tag> customTags, Label[] keys, String[] values) {
+      init(customTags, keys, values);
+    }
+
+    void init(Iterable<Tag> customTags, Label[] keys, String[] values) {
+      this.customTags = customTags;
+      this.keys = keys;
+      this.values = values;
+    }
+
+    TagsData copy() {
+      if (customTags == null) {
+        return new TagsData(null, keys, values);
+      }
+      // Copy the custom tags, the user-provided iterable may retain objects that should be collected later
+      ArrayList<Tag> tags = new ArrayList<>();
+      for (Tag tag : customTags) {
+        // The only Tag implementation provided by Micrometer is immutable
+        // but users may provide their own
+        tags.add(new ImmutableTag(tag.getKey(), tag.getValue()));
+      }
+      tags.trimToSize();
+      // No need to copy keys and values, they come from our implementation
+      return new TagsData(tags, keys, values);
+    }
+
+    @Override
+    public void close() {
+      init(null, null, null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      TagsData other = (TagsData) o;
+      if (customTags == null) {
+        if (other.customTags != null) {
+          return false;
+        }
+      } else if (other.customTags == null) {
+        return false;
+      } else {
+        Iterator<Tag> iter = customTags.iterator();
+        Iterator<Tag> otherIter = other.customTags.iterator();
+        while (iter.hasNext()) {
+          if (!otherIter.hasNext()) {
+            return false;
+          }
+          Tag tag1 = iter.next();
+          Tag tag2 = otherIter.next();
+          if (!tag1.getKey().equals(tag2.getKey()) || !tag1.getValue().equals(tag2.getValue())) {
+            return false;
+          }
+        }
+        if (otherIter.hasNext()) {
+          return false;
+        }
+      }
+      return Arrays.equals(keys, other.keys) && Arrays.equals(values, other.values);
+    }
+
+    @Override
+    public int hashCode() {
+      int result;
+      if (customTags == null) {
+        result = 0;
+      } else {
+        result = 1;
+        for (Tag tag : customTags) {
+          result = 31 * result + tag.getKey().hashCode();
+          result = 31 * result + tag.getValue().hashCode();
+        }
+      }
+      result = 31 * result + Arrays.hashCode(keys);
+      result = 31 * result + Arrays.hashCode(values);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return "TagsData{" +
+        "customTags=" + StreamSupport.stream(customTags.spliterator(), false).collect(toList()) +
+        ", keys=" + Arrays.toString(keys) +
+        ", values=" + Arrays.toString(values) +
+        '}';
+    }
+  }
+
+  private TagsCache() {
+    // Utility
+  }
+}

--- a/src/main/java/io/vertx/micrometer/impl/meters/Timers.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Timers.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.vertx.micrometer.Label;
-import io.vertx.micrometer.impl.Labels;
 
 import java.util.concurrent.TimeUnit;
 
@@ -49,7 +48,7 @@ public class Timers {
   }
 
   public Timer get(Iterable<Tag> customTags, String... values) {
-    Tags tags = Tags.of(Labels.toTags(keys, values)).and(customTags);
+    Tags tags = TagsCache.getOrCreate(customTags, keys, values);
     return Timer.builder(name)
       .description(description)
       .tags(tags)

--- a/src/test/java/io/vertx/micrometer/impl/LabelsTest.java
+++ b/src/test/java/io/vertx/micrometer/impl/LabelsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.micrometer.impl;
+
+import io.micrometer.core.instrument.Tags;
+import io.vertx.micrometer.Label;
+import org.junit.Test;
+
+import static io.vertx.micrometer.Label.*;
+import static org.junit.Assert.*;
+
+public class LabelsTest {
+
+  @Test
+  public void toTags() {
+    Tags expected, actual;
+
+    expected = Tags.empty();
+    actual = Labels.toTags(new Label[]{}, new String[]{null, "/eventbus/*"});
+    assertEquals(expected, actual);
+
+    expected = Tags.of(HTTP_CODE.toString(), "200");
+    actual = Labels.toTags(new Label[]{HTTP_CODE}, new String[]{"200"});
+    assertEquals(expected, actual);
+
+    expected = Tags.of(HTTP_CODE.toString(), "200", HTTP_ROUTE.toString(), "/eventbus/*");
+    actual = Labels.toTags(new Label[]{HTTP_CODE, HTTP_ROUTE}, new String[]{"200", "/eventbus/*"});
+    assertEquals(expected, actual);
+
+    expected = Tags.of(HTTP_ROUTE.toString(), "/eventbus/*");
+    actual = Labels.toTags(new Label[]{HTTP_CODE, HTTP_ROUTE}, new String[]{null, "/eventbus/*"});
+    assertEquals(expected, actual);
+
+    expected = Tags.empty();
+    actual = Labels.toTags(new Label[]{HTTP_CODE, HTTP_ROUTE}, new String[]{null, null});
+    assertEquals(expected, actual);
+  }
+}

--- a/src/test/java/io/vertx/micrometer/impl/meters/TagsDataTest.java
+++ b/src/test/java/io/vertx/micrometer/impl/meters/TagsDataTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.micrometer.impl.meters;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.vertx.micrometer.Label;
+import io.vertx.micrometer.impl.meters.TagsCache.TagsData;
+import org.junit.Test;
+
+import static io.vertx.micrometer.Label.*;
+import static org.junit.Assert.*;
+
+public class TagsDataTest {
+
+  @Test
+  public void testAutoCloseable() {
+    TagsData value = new TagsData(Tags.of(Tag.of("john", "doe")), new Label[]{LOCAL}, new String[]{"localhost"});
+    value.close();
+    assertNull(value.customTags);
+    assertNull(value.keys);
+    assertNull(value.values);
+  }
+
+  @Test
+  public void copy() {
+    Tags customTags = Tags.of(Tag.of("john", "doe"));
+    Label[] keys = {REMOTE};
+    String[] values = {"webserver.mycorp.int"};
+
+    TagsData original = new TagsData(customTags, keys, values);
+    TagsData copy = original.copy();
+
+    assertEquals(original.hashCode(), copy.hashCode());
+    assertEquals(original, copy);
+
+    assertNotSame(original.customTags, copy.customTags);
+    assertNotSame(original.customTags.iterator().next(), copy.customTags.iterator().next());
+  }
+
+  @Test
+  public void copyNoCustomTags() {
+    Label[] keys = {HTTP_METHOD};
+    String[] values = {"GET"};
+
+    TagsData original = new TagsData(null, keys, values);
+    TagsData copy = original.copy();
+
+    equals(original, copy);
+
+    assertNull(copy.customTags);
+  }
+
+  @Test
+  public void testNotEquals() {
+    Tag john = Tag.of("john", "doe");
+    Tag jane = Tag.of("jane", "doe");
+    Tag durant = Tag.of("john", "durant");
+
+    notEquals(
+      new TagsData(Tags.of(jane, john), new Label[]{LOCAL}, new String[]{"localhost"}),
+      new TagsData(Tags.of(jane, durant), new Label[]{LOCAL}, new String[]{"localhost"})
+    );
+
+    notEquals(
+      new TagsData(Tags.of(john, jane), new Label[]{LOCAL}, new String[]{"localhost"}),
+      new TagsData(Tags.of(jane, jane), new Label[]{LOCAL}, new String[]{"localhost"})
+    );
+
+    notEquals(
+      new TagsData(Tags.of(jane), new Label[]{LOCAL}, new String[]{"localhost"}),
+      new TagsData(Tags.of(jane, john), new Label[]{LOCAL}, new String[]{"localhost"})
+    );
+
+    notEquals(
+      new TagsData(null, new Label[]{LOCAL}, new String[]{"localhost"}),
+      new TagsData(Tags.of(jane), new Label[]{LOCAL}, new String[]{"localhost"})
+    );
+
+    notEquals(
+      new TagsData(Tags.of(john), new Label[]{LOCAL}, new String[]{"localhost"}),
+      new TagsData(null, new Label[]{LOCAL}, new String[]{"localhost"})
+    );
+
+  }
+
+  private void equals(TagsData t1, TagsData t2) {
+    assertEquals(t1, t2);
+    assertEquals(t1.hashCode(), t2.hashCode());
+  }
+
+  private void notEquals(TagsData t1, TagsData t2) {
+    assertNotEquals(t1, t2);
+    assertNotEquals(t1.hashCode(), t2.hashCode());
+  }
+}


### PR DESCRIPTION
The SPI implementation makes a lot of redundant copies and allocations when resolving tags/gauges or mapping meter ids.

See individual commit messages for details about the problems and the changes.

This PR has been tested with https://github.com/tsegismont/vertx-mysql-client-gc-nepotism, running the app for about 5 mins and capturing data with JFR.

The results in Mission Control memory section: (for reference, 53.2MB of MySQL ColumnDefinition allocated over this period)

- `ArrayList$Itr` instances down to 1.81MB, was 111MB
- `ImmutableTag` instances are no longer visible, was 83MB
- `Tag[]` instances are no longer visible, was 74.6MB
- `Tags` instances are no longer visible, was 43.3MB
- `ValueSupplier` instances are no longer visible in Mission Control, was 26.8MB
- java streams related instances are no longer visible, was 384MB
- `MeterFilter` lambda instances are no longer visible, was 28.4MB

The GC logs show pauses for young gen collection every 8490 ms instead of every 4642 ms.