### PR TITLE
fix(noopGauge): fix NoopGauge going to infinite

### DIFF
--- a/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/Gauges.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.noop.NoopGauge;
 import io.vertx.micrometer.Label;
 import io.vertx.micrometer.impl.Labels;
 
@@ -70,6 +71,10 @@ public class Gauges<T> {
     for (; ; ) {
       res = gauges.get(gaugeId);
       if (res != null) {
+        break;
+      }
+      if (gauge instanceof NoopGauge) {
+        res = candidate;
         break;
       }
       ensureGetterInvoked(gauge);


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:
When applying a Meter filter that return MeterFilterReply.DENY, a Gauge of type NoopGauge is returned, which is making the function not being executed then gauge.value() is called. This cause the Gauges.get method going on a infinity loop because of the `if (candidateFunc.invoked)` always returning false.

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
