### PR TITLE
Fix a typo in the `http_server` metrics documentation

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -645,7 +645,7 @@ The actual names may vary depending on the metrics backend.
 |Summary
 |Size in bytes of the responses.
 
-|`vertx_http_client_active_ws_connections`
+|`vertx_http_server_active_ws_connections`
 |`local`, `remote`
 |Gauge
 |Number of websockets currently opened.


### PR DESCRIPTION
This metrics should be named `vertx_http_server_active_ws_connections` and not `vertx_http_client_active_ws_connections`. See https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java#L64