### PR TITLE
Move blocking stop operation to executor thread to keep pipeline reac…

### DIFF
--- a/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static io.vertx.micrometer.MetricsDomain.*;
 
@@ -57,6 +59,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
   private final VertxPoolMetrics poolMetrics;
   private final Map<String, VertxClientMetrics> mapClientMetrics = new ConcurrentHashMap<>();
   private final Set<String> disabledCategories = new HashSet<>();
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
   public VertxMetricsImpl(MicrometerMetricsOptions options, BackendRegistry backendRegistry, ConcurrentMap<Meter.Id, Object> gaugesTable) {
     super(backendRegistry.getMeterRegistry(), gaugesTable);
@@ -160,6 +163,8 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
 
   @Override
   public void close() {
-    BackendRegistries.stop(registryName);
+    executor.execute(() -> {
+      BackendRegistries.stop(registryName);
+    });
   }
 }


### PR DESCRIPTION
Hi ! :) 
Apparently the BackendRegistries has a blocking call that occurs when we are closing the metrics..

<img width="1215" alt="Screen Shot 2023-07-13 at 4 36 58 PM" src="https://github.com/vert-x3/vertx-micrometer-metrics/assets/56495631/0db7b20a-b557-4ec7-90dc-11ea60997e0b">

This PR fixes the blocking to ensure the pipeline remains reactive.
