### PR TITLE
Deprecate setting a MeterRegistry on MicrometerMetricsOptions

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -312,7 +312,7 @@ link:http://micrometer.io/docs/concepts#_registry[Micrometer doc].
 === Reusing an existing registry
 
 It is possible to reuse an existing Micrometer registry (or `CollectorRegistry` from the Prometheus Java client),
-and inject it into the Vert.x metrics options:
+and inject it into the Vert.x instance using a {@link io.vertx.core.VertxBuilder}:
 
 [source,$lang]
 ----

--- a/src/main/java/examples/MicrometerMetricsExamples.java
+++ b/src/main/java/examples/MicrometerMetricsExamples.java
@@ -40,16 +40,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.docgen.Source;
 import io.vertx.ext.web.Router;
-import io.vertx.micrometer.Label;
-import io.vertx.micrometer.Match;
-import io.vertx.micrometer.MetricsDomain;
-import io.vertx.micrometer.MetricsNaming;
-import io.vertx.micrometer.MetricsService;
-import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.PrometheusScrapingHandler;
-import io.vertx.micrometer.VertxInfluxDbOptions;
-import io.vertx.micrometer.VertxJmxMetricsOptions;
-import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.*;
 import io.vertx.micrometer.backends.BackendRegistries;
 
 import java.util.Collections;
@@ -256,10 +247,12 @@ public class MicrometerMetricsExamples {
     myRegistry.add(new JmxMeterRegistry(s -> null, Clock.SYSTEM));
     myRegistry.add(new GraphiteMeterRegistry(s -> null, Clock.SYSTEM));
 
-    Vertx vertx = Vertx.vertx(new VertxOptions()
-      .setMetricsOptions(new MicrometerMetricsOptions()
-        .setMicrometerRegistry(myRegistry)
-        .setEnabled(true)));
+    Vertx vertx = Vertx.builder()
+      .with(new VertxOptions()
+        .setMetricsOptions(new MicrometerMetricsOptions()
+          .setEnabled(true)))
+      .withMetrics(new MicrometerMetricsFactory(myRegistry))
+      .build();
   }
 
   public void enableQuantiles() {
@@ -294,12 +287,14 @@ public class MicrometerMetricsExamples {
 
     // It's reused in MicrometerMetricsOptions.
     // Prometheus options configured here, such as "setPublishQuantiles(true)", will affect the whole registry.
-    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
-      new MicrometerMetricsOptions()
-        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true)
-          .setPublishQuantiles(true))
-        .setMicrometerRegistry(registry)
-        .setEnabled(true)));
+    Vertx.builder()
+      .with(new VertxOptions().setMetricsOptions(
+        new MicrometerMetricsOptions()
+          .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true)
+            .setPublishQuantiles(true))
+          .setEnabled(true)))
+      .withMetrics(new MicrometerMetricsFactory(registry))
+      .build();
   }
 
   public void useV3CompatNames() {

--- a/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
+++ b/src/main/java/io/vertx/micrometer/MicrometerMetricsOptions.java
@@ -307,32 +307,17 @@ public class MicrometerMetricsOptions extends MetricsOptions {
   }
 
   /**
-   * Get the Micrometer MeterRegistry to be used by Vert.x, that has been previously set programmatically
-   *
-   * @return the micrometer registry.
+   * @deprecated see {@link #setMicrometerRegistry(MeterRegistry)}
    */
+  @Deprecated
   public MeterRegistry getMicrometerRegistry() {
     return micrometerRegistry;
   }
 
   /**
-   * Programmatically set the Micrometer MeterRegistry to be used by Vert.x.
-   *
-   * This is useful in several scenarios, such as:
-   * <ul>
-   *   <li>if there is already a MeterRegistry used in the application
-   * that should be used by Vert.x as well.</li>
-   *   <li>to define some backend configuration that is not covered in this module
-   * (example: reporting to non-covered backends such as New Relic)</li>
-   *   <li>to use Micrometer's CompositeRegistry</li>
-   * </ul>
-   *
-   * This setter is mutually exclusive with setInfluxDbOptions/setPrometheusOptions/setJmxMetricsOptions
-   * and takes precedence over them.
-   *
-   * @param micrometerRegistry the registry to use
-   * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link MicrometerMetricsFactory(MeterRegistry)}
    */
+  @Deprecated
   public MicrometerMetricsOptions setMicrometerRegistry(MeterRegistry micrometerRegistry) {
     this.micrometerRegistry = micrometerRegistry;
     return this;

--- a/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
+++ b/src/main/java/io/vertx/micrometer/backends/BackendRegistries.java
@@ -58,16 +58,16 @@ public final class BackendRegistries {
    *                If the class is not recognized, a {@link NoopBackendRegistry} will be returned.
    * @return the created (or existing) {@link BackendRegistry}
    */
-  public static BackendRegistry setupBackend(MicrometerMetricsOptions options) {
+  public static BackendRegistry setupBackend(MicrometerMetricsOptions options, MeterRegistry meterRegistry) {
     return REGISTRIES.computeIfAbsent(options.getRegistryName(), k -> {
       final BackendRegistry reg;
-      if (options.getMicrometerRegistry() != null) {
-        if (options.getPrometheusOptions() != null && options.getMicrometerRegistry() instanceof PrometheusMeterRegistry) {
+      if (meterRegistry != null) {
+        if (options.getPrometheusOptions() != null && meterRegistry instanceof PrometheusMeterRegistry) {
           // If a Prometheus registry is provided, extra initialization steps may have to be performed
-          reg = new PrometheusBackendRegistry(options.getPrometheusOptions(), (PrometheusMeterRegistry) options.getMicrometerRegistry());
+          reg = new PrometheusBackendRegistry(options.getPrometheusOptions(), (PrometheusMeterRegistry) meterRegistry);
         } else {
           // Other backend registries have no special extra steps
-          reg = options::getMicrometerRegistry;
+          reg = () -> meterRegistry;
         }
       } else if (options.getInfluxDbOptions() != null && options.getInfluxDbOptions().isEnabled()) {
         reg = new InfluxDbBackendRegistry(options.getInfluxDbOptions());

--- a/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
@@ -84,7 +84,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
       : new VertxPoolMetrics(registry, names, gaugesTable);
   }
 
-  void init() {
+  public void init() {
     backendRegistry.init();
   }
 

--- a/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -14,4 +14,4 @@
 #  You may elect to redistribute this code under either of these licenses.
 #
 
-io.vertx.micrometer.impl.VertxMetricsFactoryImpl
+io.vertx.micrometer.MicrometerMetricsFactory

--- a/src/test/java/io/vertx/micrometer/EmptyCompositeMeterRegistryTest.java
+++ b/src/test/java/io/vertx/micrometer/EmptyCompositeMeterRegistryTest.java
@@ -17,6 +17,7 @@
 
 package io.vertx.micrometer;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -26,18 +27,14 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class EmptyCompositeMeterRegistryTest extends MicrometerMetricsTestBase {
 
-  @Override
-  protected MicrometerMetricsOptions metricOptions() {
-    CompositeMeterRegistry emptyCompositeRegistry = new CompositeMeterRegistry();
-    return new MicrometerMetricsOptions()
-      .setRegistryName(registryName)
-      .setMicrometerRegistry(emptyCompositeRegistry)
-      .setEnabled(true);
-  }
-
   @Test
   public void simplyStarts(TestContext ctx) {
     vertx = vertx(ctx);
+
+    meterRegistry = new CompositeMeterRegistry();
+    metricsOptions = new MicrometerMetricsOptions()
+      .setRegistryName(registryName)
+      .setEnabled(true);
 
     // If the task is executed then the gauge lookup succedeed
     vertx.executeBlocking(prom -> prom.complete(), ctx.asyncAssertSuccess());

--- a/src/test/java/io/vertx/micrometer/MicrometerMetricsTestBase.java
+++ b/src/test/java/io/vertx/micrometer/MicrometerMetricsTestBase.java
@@ -21,6 +21,7 @@ package io.vertx.micrometer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -41,6 +42,7 @@ public class MicrometerMetricsTestBase {
 
   protected String registryName;
   protected MicrometerMetricsOptions metricsOptions;
+  protected MeterRegistry meterRegistry;
   protected Vertx vertx;
 
   @Before
@@ -53,6 +55,10 @@ public class MicrometerMetricsTestBase {
     metricsOptions = metricOptions();
   }
 
+  protected MeterRegistry meterRegistry() {
+    return meterRegistry;
+  }
+
   protected MicrometerMetricsOptions metricOptions() {
     return new MicrometerMetricsOptions()
       .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
@@ -61,7 +67,16 @@ public class MicrometerMetricsTestBase {
   }
 
   protected Vertx vertx(TestContext context) {
-    return Vertx.vertx(new VertxOptions().setMetricsOptions(metricsOptions))
+    MeterRegistry meterRegistry = meterRegistry();
+    VertxBuilder builder = Vertx
+      .builder()
+      .with(new VertxOptions()
+        .setMetricsOptions(metricsOptions));
+    if (meterRegistry != null) {
+      builder.withMetrics(new MicrometerMetricsFactory(meterRegistry));
+    }
+    return builder
+      .build()
       .exceptionHandler(context.exceptionHandler());
   }
 

--- a/src/test/java/io/vertx/micrometer/backend/CustomMicrometerMetricsITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/CustomMicrometerMetricsITest.java
@@ -87,9 +87,9 @@ public class CustomMicrometerMetricsITest extends MicrometerMetricsTestBase {
       }
     }, Clock.SYSTEM));
 
+    meterRegistry = myRegistry;
 
     metricsOptions = new MicrometerMetricsOptions()
-      .setMicrometerRegistry(myRegistry)
       .setRegistryName(registryName)
       .addDisabledMetricsCategory(MetricsDomain.HTTP_SERVER)
       .addDisabledMetricsCategory(MetricsDomain.NAMED_POOLS)
@@ -121,12 +121,12 @@ public class CustomMicrometerMetricsITest extends MicrometerMetricsTestBase {
   public void shouldPublishQuantilesWithProvidedRegistry(TestContext context) throws Exception {
     PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
+    meterRegistry = registry;
     metricsOptions = new MicrometerMetricsOptions()
       .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true)
         .setPublishQuantiles(true)
         .setStartEmbeddedServer(true)
         .setEmbeddedServerOptions(new HttpServerOptions().setPort(9090)))
-      .setMicrometerRegistry(registry)
       .setEnabled(true);
 
     vertx = vertx(context);

--- a/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
+++ b/src/test/java/io/vertx/micrometer/service/MetricsServiceImplTest.java
@@ -175,9 +175,9 @@ public class MetricsServiceImplTest extends MicrometerMetricsTestBase {
 
   @Test
   public void shouldGetJvmMetricsInSnapshot(TestContext ctx) {
+    meterRegistry = new SimpleMeterRegistry();
     metricsOptions = new MicrometerMetricsOptions()
       .setJvmMetricsEnabled(true)
-      .setMicrometerRegistry(new SimpleMeterRegistry())
       .setRegistryName(registryName)
       .setEnabled(true);
 


### PR DESCRIPTION
Instead expose the metrics factory as part of public API and set it on the factory.
