### PR TITLE
LongGaugeBuilder: always set the meterId field of the supplier

### DIFF
--- a/src/main/java/io/vertx/micrometer/impl/meters/LongGaugeBuilder.java
+++ b/src/main/java/io/vertx/micrometer/impl/meters/LongGaugeBuilder.java
@@ -51,15 +51,7 @@ public class LongGaugeBuilder {
 
   public LongAdder register(MeterRegistry registry) {
     Meter.Id meterId = builder.register(registry).getId();
-    LongAdder res = longGauges.get(meterId);
-    if (res == null) {
-      LongAdder candidate = new LongAdder();
-      if ((res = longGauges.putIfAbsent(meterId, candidate)) == null) {
-        res = candidate;
-        supplier.setId(meterId);
-        return res;
-      }
-    }
-    return res;
+    supplier.setId(meterId);
+    return longGauges.computeIfAbsent(meterId, id -> new LongAdder());
   }
 }


### PR DESCRIPTION
See #232

This costs a volatile write, even when the supplier is not actually used (because the meter was previously registered).

But it's the only way to make sure the registered meter always has a properly initialized value supplier.