### PR TITLE
Clean test verticle deployments

### DIFF
--- a/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxEventBusMetricsTest.java
@@ -57,7 +57,7 @@ public class VertxEventBusMetricsTest extends MicrometerMetricsTestBase {
     // Setup eventbus handler
     vertx.deployVerticle(() -> new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> future) {
+      public void start(Promise<Void> startPromise) {
         vertx.eventBus().consumer("testSubject", msg -> {
           JsonObject body = (JsonObject) msg.body();
           try {
@@ -71,10 +71,9 @@ public class VertxEventBusMetricsTest extends MicrometerMetricsTestBase {
           if (body.getBoolean("fail")) {
             throw new RuntimeException("It's ok! [expected failure]");
           }
-        });
-        ebReady.countDown();
+        }).completion().onComplete(startPromise);
       }
-    }, new DeploymentOptions().setInstances(instances));
+    }, new DeploymentOptions().setInstances(instances)).onComplete(context.asyncAssertSuccess(v -> ebReady.complete()));
 
     ebReady.awaitSuccess();
     // Send to eventbus

--- a/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxHttpServerMetricsConfigTest.java
@@ -81,22 +81,18 @@ public class VertxHttpServerMetricsConfigTest extends MicrometerMetricsTestBase 
     Async serverReady = ctx.async();
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> future) throws Exception {
+      public void start(Promise<Void> startPromise) {
         httpServer = vertx.createHttpServer();
         httpServer
           .requestHandler(req -> {
             vertx.setTimer(30L, handler ->
               req.response().setChunked(true).putHeader("Content-Type", "text/plain").end(""));
           })
-          .listen(9195, "127.0.0.1").onComplete(r -> {
-            if (r.failed()) {
-              ctx.fail(r.cause());
-            } else {
-              serverReady.complete();
-            }
-          });
+          .listen(9195, "127.0.0.1")
+          .<Void>mapEmpty()
+          .onComplete(startPromise);
       }
-    });
+    }).onComplete(ctx.asyncAssertSuccess(v -> serverReady.complete()));
     serverReady.awaitSuccess();
   }
 

--- a/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/VertxNetClientServerMetricsTest.java
@@ -51,19 +51,15 @@ public class VertxNetClientServerMetricsTest extends MicrometerMetricsTestBase {
     Async serverReady = ctx.async();
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> future) throws Exception {
+      public void start(Promise<Void> startPromise) {
         netServer = vertx.createNetServer();
         netServer
           .connectHandler(socket -> socket.handler(buffer -> socket.write(SERVER_RESPONSE)))
-          .listen(9194, "localhost").onComplete(r -> {
-            if (r.failed()) {
-              ctx.fail(r.cause());
-            } else {
-              serverReady.complete();
-            }
-          });
+          .listen(9194, "localhost")
+          .<Void>mapEmpty()
+          .onComplete(startPromise);
       }
-    });
+    }).onComplete(ctx.asyncAssertSuccess(v -> serverReady.complete()));
     serverReady.awaitSuccess();
   }
 


### PR DESCRIPTION
This is an attempt to fix intermittent build failures.

In some cases (only on CI), some tests fail because a previous test could not close properly a net or http server (java.net.BindException: Address already in use).

When this happens, the CI logs also print a message indicating a failure to properly close a server:

```
2024-09-05T05:02:17.7401756Z Sep 05, 2024 5:02:17 AM io.netty.util.concurrent.DefaultPromise safeExecute
2024-09-05T05:02:17.7410618Z SEVERE: Failed to submit a listener notification task. Event loop shut down?
2024-09-05T05:02:17.7412174Z java.util.concurrent.RejectedExecutionException: event executor terminated
2024-09-05T05:02:17.7413826Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:931)
2024-09-05T05:02:17.7415853Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:350)
2024-09-05T05:02:17.7417941Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:343)
2024-09-05T05:02:17.7419788Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:833)
2024-09-05T05:02:17.7421765Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.execute0(SingleThreadEventExecutor.java:824)
2024-09-05T05:02:17.7423694Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:814)
2024-09-05T05:02:17.7425432Z 	at io.netty.util.concurrent.DefaultPromise.safeExecute(DefaultPromise.java:862)
2024-09-05T05:02:17.7427177Z 	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:500)
2024-09-05T05:02:17.7428763Z 	at io.netty.util.concurrent.DefaultPromise.addListener(DefaultPromise.java:185)
2024-09-05T05:02:17.7430369Z 	at io.netty.channel.DefaultChannelPromise.addListener(DefaultChannelPromise.java:95)
2024-09-05T05:02:17.7432106Z 	at io.netty.channel.DefaultChannelPromise.addListener(DefaultChannelPromise.java:30)
2024-09-05T05:02:17.7434075Z 	at io.vertx.core.net.impl.NetServerImpl.lambda$actualClose$12(NetServerImpl.java:650)
2024-09-05T05:02:17.7435573Z 	at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176)
2024-09-05T05:02:17.7437457Z 	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:68)
2024-09-05T05:02:17.7438885Z 	at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:231)
2024-09-05T05:02:17.7440198Z 	at io.vertx.core.impl.future.FutureImpl.onComplete(FutureImpl.java:199)
2024-09-05T05:02:17.7441321Z 	at io.vertx.core.net.impl.NetServerImpl.actualClose(NetServerImpl.java:643)
2024-09-05T05:02:17.7442279Z 	at io.vertx.core.net.impl.NetServerImpl.doClose(NetServerImpl.java:632)
2024-09-05T05:02:17.7443537Z 	at io.vertx.core.net.impl.NetServerImpl.close(NetServerImpl.java:172)
2024-09-05T05:02:17.7444943Z 	at io.vertx.core.internal.CloseFuture.cascadeClose(CloseFuture.java:151)
2024-09-05T05:02:17.7446072Z 	at io.vertx.core.internal.CloseFuture.close(CloseFuture.java:119)
2024-09-05T05:02:17.7447319Z 	at io.vertx.core.impl.DeploymentManager$VerticleHolder.close(DeploymentManager.java:270)
2024-09-05T05:02:17.7449150Z 	at io.vertx.core.impl.DeploymentManager$DeploymentImpl.lambda$rollback$1(DeploymentManager.java:326)
2024-09-05T05:02:17.7450737Z 	at io.vertx.core.impl.future.SucceededFuture.onComplete(SucceededFuture.java:81)
2024-09-05T05:02:17.7452324Z 	at io.vertx.core.impl.DeploymentManager$DeploymentImpl.rollback(DeploymentManager.java:306)
2024-09-05T05:02:17.7453950Z 	at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$4(DeploymentManager.java:243)
2024-09-05T05:02:17.7455380Z 	at io.vertx.core.impl.future.FutureImpl$4.onFailure(FutureImpl.java:188)
2024-09-05T05:02:17.7456757Z 	at io.vertx.core.impl.future.FutureBase.lambda$emitFailure$1(FutureBase.java:77)
2024-09-05T05:02:17.7458984Z 	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148)
2024-09-05T05:02:17.7460501Z 	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141)
2024-09-05T05:02:17.7462309Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
2024-09-05T05:02:17.7463989Z 	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:154)
2024-09-05T05:02:17.7465565Z 	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
2024-09-05T05:02:17.7467135Z 	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2024-09-05T05:02:17.7468739Z 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2024-09-05T05:02:17.7470017Z 	at java.base/java.lang.Thread.run(Thread.java:840)
```

Looking at the tests that deploy verticles, it seems most of them don't manage the start promise properly.

Perhaps Vert.x does not close properly servers started by a verticle if the deployment hasn't been completed.

This may be solved by https://github.com/eclipse-vertx/vert.x/pull/5296

But it's best to make sure the test verticle are deployed properly.