### PR TITLE
Upgrade micrometer to 1.13.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <assertj.version>3.9.0</assertj.version>
     <junit.version>4.13.1</junit.version>
-    <micrometer.version>1.13.5</micrometer.version>
+    <micrometer.version>1.13.6</micrometer.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Release notes: https://github.com/micrometer-metrics/micrometer/releases/tag/v1.13.6

>  ⭐ New Features / Enhancements
> Improve memory usage of StepBucketHistogram https://github.com/micrometer-metrics/micrometer/issues/4954
> 🐞 Bug Fixes
> Instrumented Java 11 HttpClient does not re-throw exceptions in sendAsync call https://github.com/micrometer-metrics/micrometer/issues/5136
> Map time units to UCUM format for Dynatrace https://github.com/micrometer-metrics/micrometer/issues/5588
> Aspects' tagsBasedOnJoinPoint may throw uncaught exception https://github.com/micrometer-metrics/micrometer/issues/5584
> Set user agent header in OTLP registry https://github.com/micrometer-metrics/micrometer/issues/5577
> MicrometerHttpRequestExecutor fails to instrument with Apache HC 5.4 https://github.com/micrometer-metrics/micrometer/issues/5575

> 📔 Documentation
> Remove duplicated context-propagation documentation in Micrometer docs https://github.com/micrometer-metrics/micrometer/issues/5549
> [OTLP Registry] Document batch size configuration https://github.com/micrometer-metrics/micrometer/issues/5578
> 🔨 Dependency Upgrades
> Bump dropwizard-metrics from 4.2.27 to 4.2.28 https://github.com/micrometer-metrics/micrometer/pull/5566
> Bump context-propagation to 1.1.2 https://github.com/micrometer-metrics/micrometer/issues/5592

> 📝 Tasks
> Bump org.junit:junit-bom from 5.10.4 to 5.10.5 https://github.com/micrometer-metrics/micrometer/pull/5571
> Bump me.champeau.gradle:japicmp-gradle-plugin from 0.4.3 to 0.4.4 https://github.com/micrometer-metrics/micrometer/pull/5567
> Bump jersey3 from 3.0.12 to 3.0.16 https://github.com/micrometer-metrics/micrometer/pull/5560
> Do not include formerly removed micrometer-samples-jetty12 subproject https://github.com/micrometer-metrics/micrometer/issues/5554
> Bump spring from 5.3.37 to 5.3.39 https://github.com/micrometer-metrics/micrometer/pull/5419
> Bump org.junit.platform:junit-platform-launcher from 1.10.4 to 1.10.5 https://github.com/micrometer-metrics/micrometer/pull/5557
> Bump org.mongodb:mongodb-driver-sync from 4.11.3 to 4.11.4 https://github.com/micrometer-metrics/micrometer/pull/5538
> Bump uk.org.webcompere:system-stubs-jupiter from 2.1.6 to 2.1.7 https://github.com/micrometer-metrics/micrometer/pull/5536
> Bump io.netty:netty-bom from 4.1.112.Final to 4.1.114.Final https://github.com/micrometer-metrics/micrometer/pull/5534
> Bump io.spring.develocity.conventions from 0.0.20 to 0.0.22 https://github.com/micrometer-metrics/micrometer/pull/5533
> Bump org.junit.platform:junit-platform-launcher from 1.10.3 to 1.10.4 https://github.com/micrometer-metrics/micrometer/pull/5532
> Bump jetty9 from 9.4.55.v20240627 to 9.4.56.v20240826 https://github.com/micrometer-metrics/micrometer/pull/5531
> Bump junit from 5.10.3 to 5.10.4 https://github.com/micrometer-metrics/micrometer/pull/5530
> Bump spring from 5.3.37 to 5.3.39 https://github.com/micrometer-metrics/micrometer/pull/5455
> 