### PR TITLE
Upgrade Micrometer to 1.14.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <assertj.version>3.9.0</assertj.version>
     <junit.version>4.13.1</junit.version>
-    <micrometer.version>1.14.2</micrometer.version>
+    <micrometer.version>1.14.3</micrometer.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
https://github.com/micrometer-metrics/micrometer/releases/tag/v1.14.3

# Bug Fixes

> - Handle RuntimeException when getting/setting JMS headers https://github.com/micrometer-metrics/micrometer/pull/5746
> - NPE occurs when AOP is applied to a method that returns CompletableFuture https://github.com/micrometer-metrics/micrometer/issues/5741
> - Performance regression in MeterRegistry#remove with many meters https://github.com/micrometer-metrics/micrometer/issues/5466
> - Exponential histogram throws ArrayIndexOutOfBoundsException https://github.com/micrometer-metrics/micrometer/issues/5740