### PR TITLE
StackOverflowError when using PrometheusOptions

### DIFF
--- a/src/test/java/io/vertx/micrometer/backend/PrometheusEmbeddedLauncherITest.java
+++ b/src/test/java/io/vertx/micrometer/backend/PrometheusEmbeddedLauncherITest.java
@@ -1,0 +1,93 @@
+package io.vertx.micrometer.backend;
+
+import io.vertx.core.Launcher;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.MyVerticle;
+import io.vertx.micrometer.VertxPrometheusOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.*;
+import static org.junit.Assert.fail;
+
+public class PrometheusEmbeddedLauncherITest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private File output;
+  private Process process;
+
+  @Before
+  public void setUp() throws Exception {
+    output = folder.newFile();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (process != null && process.isAlive()) {
+      process.destroyForcibly();
+    }
+  }
+
+  public static final class ShouldNotFailWithStackOverflowError extends Launcher {
+    public static void main(String[] args) {
+      ShouldNotFailWithStackOverflowError launcher = new ShouldNotFailWithStackOverflowError();
+      launcher.dispatch(new String[]{"run", MyVerticle.class.getName(), "--java-opts", "-Dvertx.metrics.options.enabled=true"});
+    }
+
+    @Override
+    public void beforeStartingVertx(VertxOptions options) {
+      options.setMetricsOptions(
+        (new MicrometerMetricsOptions())
+          .setEnabled(true)
+          .setPrometheusOptions(
+            (new VertxPrometheusOptions())
+              .setEnabled(true)
+              .setStartEmbeddedServer(true)
+              .setEmbeddedServerOptions((new HttpServerOptions()).setPort(8181))));
+    }
+  }
+
+  @Test
+  public void shouldNotFailWithStackOverflowError() throws Exception {
+    String javaHome = System.getProperty("java.home");
+    String classpath = System.getProperty("java.class.path");
+
+    List<String> command = new ArrayList<>();
+    command.add(javaHome + File.separator + "bin" + File.separator + "java");
+    command.add("-classpath");
+    command.add(classpath);
+    command.add(ShouldNotFailWithStackOverflowError.class.getName());
+
+    process = new ProcessBuilder(command)
+      .redirectOutput(output)
+      .redirectErrorStream(true)
+      .start();
+
+    long start = System.nanoTime();
+    do {
+      MILLISECONDS.sleep(500);
+      if (SECONDS.convert(System.nanoTime() - start, NANOSECONDS) > 5) {
+        fail("Verticle couldn't be deployed");
+      }
+    } while (!verticleDeployed());
+  }
+
+  private boolean verticleDeployed() throws Exception {
+    if (!process.isAlive()) {
+      return false;
+    }
+    return Files.readAllLines(output.toPath()).stream().anyMatch(s -> s.contains("Succeeded in deploying verticle"));
+  }
+}


### PR DESCRIPTION
Fixes #251

When the embedded server is enabled, the backend registry creates an internal Vert.x instance, for the sole purpose of serving metrics data over HTTP.

In general, it's not a problem because the default Vert.x options don't enable metrics. But if metrics are enabled with the vertx.metrics.options.enabled system property, the internal Vert.x instance will have metrics enabled too (because of code introduced to retrofit Vert.x builder in Vert.x 4). And then the application fail to start with a StackOverflow error (because the default PrometheusBackendRegistry is reused and reinitialized).

So, we can avoid that situation by making sure the internal Vert.x instance uses dummy metrics.

This problem doesn't apply to Vert.x 5.