### PR TITLE
Migrate to TransportMetrics

### DIFF
--- a/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
@@ -143,7 +143,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
   }
 
   @Override
-  public TCPMetrics<?> createNetServerMetrics(NetServerOptions netServerOptions, SocketAddress socketAddress) {
+  public TransportMetrics<?> createNetServerMetrics(NetServerOptions netServerOptions, SocketAddress socketAddress) {
     if (disabledCategories.contains(NET_SERVER.toCategory())) {
       return null;
     }
@@ -151,7 +151,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
   }
 
   @Override
-  public TCPMetrics<?> createNetClientMetrics(NetClientOptions netClientOptions) {
+  public TransportMetrics<?> createNetClientMetrics(NetClientOptions netClientOptions) {
     if (disabledCategories.contains(NET_CLIENT.toCategory())) {
       return null;
     }

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
@@ -20,7 +20,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.Tags;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.impl.VertxNetClientMetrics.NetClientSocketMetric;
 import io.vertx.micrometer.impl.tags.Labels;
@@ -33,7 +33,7 @@ import static io.vertx.micrometer.MetricsDomain.NET_CLIENT;
 /**
  * @author Joel Takvorian
  */
-class VertxNetClientMetrics extends AbstractMetrics implements TCPMetrics<NetClientSocketMetric> {
+class VertxNetClientMetrics extends AbstractMetrics implements TransportMetrics<NetClientSocketMetric> {
 
   final Tags local;
   private final MeterProvider<Counter> netErrorCount;
@@ -52,6 +52,11 @@ class VertxNetClientMetrics extends AbstractMetrics implements TCPMetrics<NetCli
     netErrorCount = Counter.builder(names.getNetErrorCount())
       .description("Number of errors")
       .withRegistry(registry);
+  }
+
+  @Override
+  public String type() {
+    return "tcp";
   }
 
   @Override

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetServerMetrics.java
@@ -19,7 +19,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tags;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.impl.VertxNetServerMetrics.NetServerSocketMetric;
 import io.vertx.micrometer.impl.tags.Labels;
@@ -32,7 +32,7 @@ import static io.vertx.micrometer.MetricsDomain.NET_SERVER;
 /**
  * @author Joel Takvorian
  */
-class VertxNetServerMetrics extends AbstractMetrics implements TCPMetrics<NetServerSocketMetric> {
+class VertxNetServerMetrics extends AbstractMetrics implements TransportMetrics<NetServerSocketMetric> {
 
   final Tags local;
   private final Meter.MeterProvider<Counter> netErrorCount;
@@ -51,6 +51,11 @@ class VertxNetServerMetrics extends AbstractMetrics implements TCPMetrics<NetSer
     netErrorCount = Counter.builder(names.getNetErrorCount())
       .description("Number of errors")
       .withRegistry(registry);
+  }
+
+  @Override
+  public String type() {
+    return "tcp";
   }
 
   @Override


### PR DESCRIPTION
In Vert.x 5.1, TCPMetrics is deprecated.

Replaces usages of this class with TransportMetrics.