### PR TITLE
Expose HttpClientOptions and NetClientOptions metricsName

### DIFF
--- a/src/main/java/io/vertx/micrometer/Label.java
+++ b/src/main/java/io/vertx/micrometer/Label.java
@@ -75,6 +75,11 @@ public enum Label {
    */
   POOL_NAME("pool_name"),
   /**
+   * Client name, such as Net and HTTP Clients
+   * @see io.vertx.core.net.ClientOptionsBase#setMetricsName(String)
+   */
+  CLIENT_NAME("client_name"),
+  /**
    * Client namespace
    */
   NAMESPACE("client_namespace");

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
@@ -47,8 +47,8 @@ class VertxHttpClientMetrics extends VertxNetClientMetrics implements HttpClient
   private final MeterProvider<Counter> responseCount;
   private final MeterProvider<DistributionSummary> responseBytes;
 
-  VertxHttpClientMetrics(AbstractMetrics parent, Function<HttpRequest, Iterable<Tag>> customTagsProvider, String localAddress) {
-    super(parent, HTTP_CLIENT, localAddress);
+  VertxHttpClientMetrics(AbstractMetrics parent, String metricsName, Function<HttpRequest, Iterable<Tag>> customTagsProvider, String localAddress) {
+    super(parent, metricsName, HTTP_CLIENT, localAddress);
     this.customTagsProvider = customTagsProvider;
     requestCount = Counter.builder(names.getHttpRequestsCount())
       .description("Number of requests sent")

--- a/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxMetricsImpl.java
@@ -139,7 +139,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     if (disabledCategories.contains(HTTP_CLIENT.toCategory())) {
       return null;
     }
-    return new VertxHttpClientMetrics(this, clientRequestTagsProvider, httpClientOptions.getLocalAddress());
+    return new VertxHttpClientMetrics(this, httpClientOptions.getMetricsName(), clientRequestTagsProvider, httpClientOptions.getLocalAddress());
   }
 
   @Override
@@ -155,7 +155,7 @@ public class VertxMetricsImpl extends AbstractMetrics implements VertxMetrics {
     if (disabledCategories.contains(NET_CLIENT.toCategory())) {
       return null;
     }
-    return new VertxNetClientMetrics(this, netClientOptions.getLocalAddress());
+    return new VertxNetClientMetrics(this, netClientOptions.getMetricsName(), netClientOptions.getLocalAddress());
   }
 
   @Override

--- a/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxNetClientMetrics.java
@@ -38,16 +38,22 @@ class VertxNetClientMetrics extends AbstractMetrics implements TransportMetrics<
   final Tags local;
   private final MeterProvider<Counter> netErrorCount;
 
-  VertxNetClientMetrics(AbstractMetrics parent, String localAddress) {
-    this(parent, NET_CLIENT, localAddress);
+  VertxNetClientMetrics(AbstractMetrics parent, String metricsName, String localAddress) {
+    this(parent, metricsName, NET_CLIENT, localAddress);
   }
 
-  VertxNetClientMetrics(AbstractMetrics parent, MetricsDomain domain, String localAddress) {
+  VertxNetClientMetrics(AbstractMetrics parent, String metricsName, MetricsDomain domain, String localAddress) {
     super(parent, domain);
-    if (enabledLabels.contains(LOCAL)) {
-      local = Tags.of(LOCAL.toString(), localAddress == null ? "?" : localAddress);
+    Tags base;
+    if (enabledLabels.contains(CLIENT_NAME)) {
+      base = Tags.of(CLIENT_NAME.toString(), metricsName == null ? "?" : metricsName);
     } else {
-      local = Tags.empty();
+      base = Tags.empty();
+    }
+    if (enabledLabels.contains(LOCAL)) {
+      local = base.and(LOCAL.toString(), localAddress == null ? "?" : localAddress);
+    } else {
+      local = base;
     }
     netErrorCount = Counter.builder(names.getNetErrorCount())
       .description("Number of errors")

--- a/src/test/java/io/vertx/micrometer/tests/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/tests/VertxHttpClientServerMetricsTest.java
@@ -59,7 +59,7 @@ public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase 
         String user = req.headers() != null ? req.headers().get("user") : null;
         return user != null ? Collections.singletonList(Tag.of("user", user)) : Collections.emptyList();
       })
-      .addLabels(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.EB_ADDRESS)
+      .addLabels(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.EB_ADDRESS, Label.CLIENT_NAME)
       .addLabelMatch(new Match()
         .setDomain(MetricsDomain.HTTP_SERVER)
         .setType(MatchType.REGEX)
@@ -132,26 +132,26 @@ public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase 
   public void shouldReportHttpClientMetrics(TestContext ctx) {
     runClientRequests(ctx, false, "jordi");
 
-    waitForValue(ctx, "vertx.http.client.bytes.read[local=?,remote=127.0.0.1:9195]$COUNT",
+    waitForValue(ctx, "vertx.http.client.bytes.read[client_name=my_client_name,local=?,remote=127.0.0.1:9195]$COUNT",
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length);
 
     List<Datapoint> datapoints = listDatapoints(startsWith("vertx.http.client."));
     assertThat(datapoints).hasSize(13).contains(
-        dp("vertx.http.client.bytes.read[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
-        dp("vertx.http.client.bytes.written[local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-        dp("vertx.http.client.request.bytes[local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-        dp("vertx.http.client.request.bytes[local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-        dp("vertx.http.client.requests[local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-        dp("vertx.http.client.response.bytes[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-        dp("vertx.http.client.response.bytes[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
-        dp("vertx.http.client.responses[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT));
+      dp("vertx.http.client.bytes.read[client_name=my_client_name,local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+      dp("vertx.http.client.bytes.written[client_name=my_client_name,local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+      dp("vertx.http.client.request.bytes[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.client.request.bytes[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+      dp("vertx.http.client.requests[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.client.response.bytes[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.client.response.bytes[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+      dp("vertx.http.client.responses[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT));
 
     assertThat(datapoints).extracting(Datapoint::id).contains(
-      "vertx.http.client.response.time[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL_TIME",
-      "vertx.http.client.response.time[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT",
-      "vertx.http.client.response.time[code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$MAX",
-      "vertx.http.client.active.requests[local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$VALUE",
-      "vertx.http.client.active.connections[local=?,remote=127.0.0.1:9195]$VALUE");
+      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL_TIME",
+      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT",
+      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$MAX",
+      "vertx.http.client.active.requests[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$VALUE",
+      "vertx.http.client.active.connections[client_name=my_client_name,local=?,remote=127.0.0.1:9195]$VALUE");
 
     datapoints = listDatapoints(dp -> dp.getId().getName().startsWith("vertx.pool.queue.") && Objects.equals(dp.getId().getTag("pool_type"), "http"));
     assertThat(datapoints).hasSize(4).contains(
@@ -242,7 +242,7 @@ public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase 
     Async clientsFinished = ctx.async(concurrentClients);
     for (int i = 0; i < concurrentClients; i++) {
       ForkJoinPool.commonPool().execute(() -> {
-        httpClient = vertx.createHttpClient();
+        httpClient = vertx.createHttpClient(new HttpClientOptions().setMetricsName("my_client_name"));
         wsClient = vertx.createWebSocketClient();
         httpRequest(httpClient, ctx, user);
         if (ws) {


### PR DESCRIPTION
See #265

Users can set metricsName in HttpClientOptions and NetClientOptions in order to group related metrics. This feature was supported in the Dropwizard implementation of the Metrics SPI but not in this one.

The configured metricsName is exposed as a tag, but this tag is disabled by default. It can be enabled in MicrometerMetricsOptions.