### PR TITLE
Deprecate MetricsNaming#v3Names

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -371,13 +371,6 @@ Since plain access to Micrometer registries is provided, it is possible to lever
 
 Each metric that Vert.x provides can be renamed through the metrics options, using
 {@link io.vertx.micrometer.MetricsNaming} and {@link io.vertx.micrometer.MicrometerMetricsOptions#setMetricsNaming}.
-The default metric names were changed in Vert.x 4 to better align with backend conventions, but it is
-still possible to retrieve the names used in Vert.x 3.x for compatibility:
-
-[source,$lang]
-----
-{@link examples.MicrometerMetricsExamples#useV3CompatNames()}
-----
 
 === Labels and matchers
 

--- a/src/main/java/examples/MicrometerMetricsExamples.java
+++ b/src/main/java/examples/MicrometerMetricsExamples.java
@@ -304,14 +304,6 @@ public class MicrometerMetricsExamples {
       .build();
   }
 
-  public void useV3CompatNames() {
-    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
-      new MicrometerMetricsOptions()
-        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
-        .setMetricsNaming(MetricsNaming.v3Names())
-        .setEnabled(true)));
-  }
-
   public void useCustomTagsProvider() {
     Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
       new MicrometerMetricsOptions()

--- a/src/main/java/io/vertx/micrometer/MetricsNaming.java
+++ b/src/main/java/io/vertx/micrometer/MetricsNaming.java
@@ -140,6 +140,10 @@ public class MetricsNaming {
     return json;
   }
 
+  /**
+   * @deprecated as of 5.1
+   */
+  @Deprecated(forRemoval = true)
   public static MetricsNaming v3Names() {
     MetricsNaming mn = new MetricsNaming();
     mn.clientQueueTime = "queue.time";


### PR DESCRIPTION
Deprecated for removal in a future version.