### PR TITLE
HTTP/3 and QUIC improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
       <artifactId>vertx-launcher-legacy-cli</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Brings native QUIC dependencies for testing -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http3</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <!-- Test dependency is for Unix socket test (linux) -->
       <groupId>io.netty</groupId>
@@ -304,28 +310,6 @@
       </build>
     </profile>
     <profile>
-      <id>linux</id>
-      <activation>
-        <os>
-          <family>linux</family>
-        </os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-native-quic</artifactId>
-          <classifier>linux-x86_64</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-native-quic</artifactId>
-          <classifier>linux-aarch_64</classifier>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
       <id>osx</id>
       <activation>
         <os>
@@ -342,30 +326,6 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <classifier>osx-aarch_64</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <classifier>osx-x86_64</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <classifier>osx-aarch_64</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-native-quic</artifactId>
-          <classifier>osx-x86_64</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-native-quic</artifactId>
           <classifier>osx-aarch_64</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/main/java/io/vertx/micrometer/Label.java
+++ b/src/main/java/io/vertx/micrometer/Label.java
@@ -50,6 +50,10 @@ public enum Label {
    */
   HTTP_CODE("code"),
   /**
+   * HTTP version: "HTTP/1.0","HTTP/1.1","HTTP/2" or "HTTP/3"
+   */
+  HTTP_VERSION("version"),
+  /**
    * Class name. When used in error counters (in net, http, datagram and eventbus domains) it relates to an exception
    * that occurred. When used in verticle domain, it relates to the verticle class name.
    */

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpClientMetrics.java
@@ -129,6 +129,9 @@ class VertxHttpClientMetrics extends AbstractMetrics implements HttpClientMetric
       if (enabledLabels.contains(HTTP_METHOD)) {
         tags = tags.and(HTTP_METHOD.toString(), request.method().toString());
       }
+      if (enabledLabels.contains(HTTP_VERSION) && request.version() != null) {
+        tags = tags.and(HTTP_VERSION.toString(), VertxHttpServerMetrics.versions.get(request.version()));
+      }
       if (customTagsProvider != null) {
         tags = tags.and(customTagsProvider.apply(request));
       }

--- a/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
+++ b/src/main/java/io/vertx/micrometer/impl/VertxHttpServerMetrics.java
@@ -17,6 +17,7 @@ package io.vertx.micrometer.impl;
 
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.Meter.MeterProvider;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Sample;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
@@ -27,9 +28,7 @@ import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.micrometer.impl.tags.Labels;
 
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
@@ -40,6 +39,15 @@ import static io.vertx.micrometer.MetricsDomain.HTTP_SERVER;
  * @author Joel Takvorian
  */
 class VertxHttpServerMetrics extends AbstractMetrics implements HttpServerMetrics<VertxHttpServerMetrics.RequestMetric, LongAdder> {
+
+  static final Map<HttpVersion, String> versions = new EnumMap<>(HttpVersion.class);
+
+  static {
+    versions.put(HttpVersion.HTTP_1_0, "HTTP/1.0");
+    versions.put(HttpVersion.HTTP_1_1, "HTTP/1.1");
+    versions.put(HttpVersion.HTTP_2, "HTTP/2");
+    versions.put(HttpVersion.HTTP_3, "HTTP/3");
+  }
 
   private final Tags tcpLocal;
   private final Tags udpLocal;
@@ -100,6 +108,9 @@ class VertxHttpServerMetrics extends AbstractMetrics implements HttpServerMetric
     }
     if (enabledLabels.contains(HTTP_METHOD)) {
       tags = tags.and(HTTP_METHOD.toString(), request.method().toString());
+    }
+    if (enabledLabels.contains(HTTP_VERSION) && request.version() != null) {
+      tags = tags.and(HTTP_VERSION.toString(), versions.get(request.version()));
     }
     if (customTagsProvider != null) {
       tags = tags.and(customTagsProvider.apply(request));

--- a/src/test/java/io/vertx/micrometer/tests/VertxHttpClientServerMetricsTest.java
+++ b/src/test/java/io/vertx/micrometer/tests/VertxHttpClientServerMetricsTest.java
@@ -59,7 +59,7 @@ public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase 
         String user = req.headers() != null ? req.headers().get("user") : null;
         return user != null ? Collections.singletonList(Tag.of("user", user)) : Collections.emptyList();
       })
-      .addLabels(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.EB_ADDRESS, Label.CLIENT_NAME)
+      .addLabels(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.EB_ADDRESS, Label.CLIENT_NAME, Label.HTTP_VERSION)
       .addLabelMatch(new Match()
         .setDomain(MetricsDomain.HTTP_SERVER)
         .setType(MatchType.REGEX)
@@ -139,18 +139,18 @@ public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase 
     assertThat(datapoints).hasSize(13).contains(
       dp("vertx.http.client.bytes.read[client_name=my_client_name,local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
       dp("vertx.http.client.bytes.written[client_name=my_client_name,local=?,remote=127.0.0.1:9195]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-      dp("vertx.http.client.request.bytes[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-      dp("vertx.http.client.request.bytes[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-      dp("vertx.http.client.requests[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-      dp("vertx.http.client.response.bytes[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-      dp("vertx.http.client.response.bytes[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
-      dp("vertx.http.client.responses[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT", concurrentClients * HTTP_SENT_COUNT));
+      dp("vertx.http.client.request.bytes[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.client.request.bytes[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+      dp("vertx.http.client.requests[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.client.response.bytes[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.client.response.bytes[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+      dp("vertx.http.client.responses[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$COUNT", concurrentClients * HTTP_SENT_COUNT));
 
     assertThat(datapoints).extracting(Datapoint::id).contains(
-      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$TOTAL_TIME",
-      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$COUNT",
-      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$MAX",
-      "vertx.http.client.active.requests[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi]$VALUE",
+      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$TOTAL_TIME",
+      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$COUNT",
+      "vertx.http.client.response.time[client_name=my_client_name,code=200,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$MAX",
+      "vertx.http.client.active.requests[client_name=my_client_name,local=?,method=POST,path=/resource,remote=127.0.0.1:9195,user=jordi,version=HTTP/1.1]$VALUE",
       "vertx.http.client.active.connections[client_name=my_client_name,local=?,remote=127.0.0.1:9195]$VALUE");
 
     datapoints = listDatapoints(dp -> dp.getId().getName().startsWith("vertx.pool.queue.") && Objects.equals(dp.getId().getTag("pool_type"), "http"));
@@ -169,27 +169,27 @@ public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase 
 
     List<Datapoint> datapoints = listDatapoints(startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).containsOnly(
-      "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.active.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$VALUE",
+      "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.active.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$VALUE",
       "vertx.http.server.active.connections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.bytes.read[local=127.0.0.1:9195,remote=_]$COUNT",
       "vertx.http.server.bytes.written[local=127.0.0.1:9195,remote=_]$COUNT",
-      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL",
-      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL",
-      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL_TIME",
-      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$MAX");
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL",
+      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL_TIME",
+      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$MAX");
 
     assertThat(datapoints).contains(
       dp("vertx.http.server.bytes.read[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
       dp("vertx.http.server.bytes.written[local=127.0.0.1:9195,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
-      dp("vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-      dp("vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
-      dp("vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT),
-      dp("vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
-      dp("vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT", concurrentClients * HTTP_SENT_COUNT));
+      dp("vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL", concurrentClients * HTTP_SENT_COUNT * CLIENT_REQUEST.getBytes().length),
+      dp("vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT", concurrentClients * HTTP_SENT_COUNT),
+      dp("vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL", concurrentClients * HTTP_SENT_COUNT * SERVER_RESPONSE.getBytes().length),
+      dp("vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT", concurrentClients * HTTP_SENT_COUNT));
   }
 
   @Test
@@ -197,41 +197,41 @@ public class VertxHttpClientServerMetricsTest extends MicrometerMetricsTestBase 
     runClientRequests(ctx, true, null);
 
     // Remark, with websockets, two extra requests are performed so increase the expected value
-    waitForValue(ctx, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
+    waitForValue(ctx, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
 
     List<Datapoint> datapoints = listDatapoints(startsWith("vertx.http.server."));
     assertThat(datapoints).extracting(Datapoint::id).containsOnly(
-      "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.active.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$VALUE",
+      "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.active.requests[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$VALUE",
       "vertx.http.server.active.connections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.active.ws.connections[local=127.0.0.1:9195,remote=_]$VALUE",
       "vertx.http.server.bytes.read[local=127.0.0.1:9195,remote=_]$COUNT",
       "vertx.http.server.bytes.written[local=127.0.0.1:9195,remote=_]$COUNT",
-      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL",
-      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL",
-      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$TOTAL_TIME",
-      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
-      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$MAX",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.response.bytes[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL",
+      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$TOTAL_TIME",
+      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.response.time[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$MAX",
       // Following ones result from the WS connection
-      "vertx.http.server.active.requests[local=127.0.0.1:9195,method=GET,path=/,remote=_]$VALUE",
-      "vertx.http.server.requests[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_]$COUNT",
-      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=GET,path=/,remote=_]$COUNT",
-      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=GET,path=/,remote=_]$TOTAL",
-      "vertx.http.server.response.bytes[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_]$COUNT",
-      "vertx.http.server.response.bytes[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_]$TOTAL",
-      "vertx.http.server.response.time[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_]$TOTAL_TIME",
-      "vertx.http.server.response.time[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_]$COUNT",
-      "vertx.http.server.response.time[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_]$MAX");
+      "vertx.http.server.active.requests[local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$VALUE",
+      "vertx.http.server.requests[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.request.bytes[local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$TOTAL",
+      "vertx.http.server.response.bytes[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.response.bytes[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$TOTAL",
+      "vertx.http.server.response.time[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$TOTAL_TIME",
+      "vertx.http.server.response.time[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$COUNT",
+      "vertx.http.server.response.time[code=101,local=127.0.0.1:9195,method=GET,path=/,remote=_,version=HTTP/1.1]$MAX");
   }
 
   @Test
   public void shouldIgnoreInternalEventbusMetrics(TestContext ctx) {
     runClientRequests(ctx, true, null);
 
-    waitForValue(ctx, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_]$COUNT",
+    waitForValue(ctx, "vertx.http.server.requests[code=200,local=127.0.0.1:9195,method=POST,path=/resource,remote=_,version=HTTP/1.1]$COUNT",
       value -> value.intValue() == concurrentClients * HTTP_SENT_COUNT);
 
     List<Datapoint> datapoints = listDatapoints(startsWith("vertx.eventbus."));


### PR DESCRIPTION
- **Update pom.xml to use netty-codec-http3 over native quic dependencies**
- **Add support for HTTP version label in HTTP client and server which is useful for splitting traffic**
